### PR TITLE
feat: per-daemon-run session logging and runtime diagnostics

### DIFF
--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -23,9 +23,6 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Manage startup and shutdown of the daemon."""
-    import os
-    from pathlib import Path
-
     # --- Startup ---
     app.state.start_time = time.time()
     app.state.background_tasks = set()
@@ -33,9 +30,22 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     settings: DaemonSettings = getattr(app.state, "settings", DaemonSettings())
     app.state.settings = settings
 
-    # Daemon session path (created by cli.py before uvicorn starts)
-    daemon_session_env = os.environ.get("_AMPLIFIERD_DAEMON_SESSION_PATH")
-    app.state.daemon_session_path = Path(daemon_session_env) if daemon_session_env else None
+    # Daemon session path (created by cli.py before uvicorn starts; read via pydantic-settings)
+    app.state.daemon_session_path = settings.daemon_session_path
+
+    # Wire up session log in worker process (needed for --reload where worker is a fresh process)
+    if app.state.daemon_session_path and app.state.daemon_session_path.exists():
+        import sys
+
+        from amplifierd.daemon_session import _TeeWriter, setup_session_log
+
+        if not isinstance(sys.stdout, _TeeWriter):
+            setup_session_log(app.state.daemon_session_path)
+
+    if app.state.daemon_session_path:
+        from amplifierd.daemon_session import update_session_meta
+
+        update_session_meta(app.state.daemon_session_path, {"status": "running"})
 
     app.state.event_bus = EventBus()
 
@@ -101,6 +111,19 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     yield
 
     # --- Shutdown ---
+    if app.state.daemon_session_path:
+        from datetime import UTC, datetime
+
+        from amplifierd.daemon_session import update_session_meta
+
+        update_session_meta(
+            app.state.daemon_session_path,
+            {
+                "status": "stopped",
+                "end_time": datetime.now(tz=UTC).isoformat(),
+            },
+        )
+
     await app.state.session_manager.shutdown()
 
 

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -23,12 +23,19 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Manage startup and shutdown of the daemon."""
+    import os
+    from pathlib import Path
+
     # --- Startup ---
     app.state.start_time = time.time()
     app.state.background_tasks = set()
 
     settings: DaemonSettings = getattr(app.state, "settings", DaemonSettings())
     app.state.settings = settings
+
+    # Daemon session path (created by cli.py before uvicorn starts)
+    daemon_session_env = os.environ.get("_AMPLIFIERD_DAEMON_SESSION_PATH")
+    app.state.daemon_session_path = Path(daemon_session_env) if daemon_session_env else None
 
     app.state.event_bus = EventBus()
 
@@ -72,6 +79,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     )
 
     # Plugin discovery — resilient
+    plugin_names: list[str] = []
     try:
         plugins = discover_plugins(
             disabled=settings.disabled_plugins,
@@ -79,9 +87,16 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         )
         for name, router in plugins:
             app.include_router(router)
+            plugin_names.append(name)
             logger.info("Mounted plugin: %s", name)
     except Exception:
         logger.warning("Plugin discovery failed; starting without plugins")
+
+    # Update daemon session meta.json with discovered plugins
+    if app.state.daemon_session_path and plugin_names:
+        from amplifierd.daemon_session import update_session_meta
+
+        update_session_meta(app.state.daemon_session_path, {"plugins": plugin_names})
 
     yield
 

--- a/src/amplifierd/cli.py
+++ b/src/amplifierd/cli.py
@@ -84,11 +84,29 @@ def serve(
         format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
     )
 
-    # 2. Create daemon session directory and route all output to serve.log
+    # 2. Global rotating server.log — survives across individual daemon sessions
+    from logging.handlers import RotatingFileHandler
+
+    global_log_dir = settings.daemon_logs_dir
+    global_log_dir.mkdir(parents=True, exist_ok=True)
+    global_handler = RotatingFileHandler(
+        str(global_log_dir / "server.log"),
+        maxBytes=10_485_760,  # 10MB
+        backupCount=3,
+        encoding="utf-8",
+    )
+    global_handler.setFormatter(
+        logging.Formatter(
+            '{"ts":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","msg":"%(message)s"}'
+        )
+    )
+    logging.getLogger().addHandler(global_handler)
+
+    # 3. Create daemon session directory and route all output to serve.log
     from amplifierd.daemon_session import create_session_dir, setup_session_log
 
     session_path = create_session_dir(
-        settings.daemon_sessions_dir,
+        settings.daemon_run_dir,
         host=effective_host,
         port=effective_port,
         log_level=effective_log_level,
@@ -96,7 +114,7 @@ def serve(
     setup_session_log(session_path)
 
     # Store the daemon session path in env so the app lifespan can pick it up
-    os.environ["_AMPLIFIERD_DAEMON_SESSION_PATH"] = str(session_path)
+    os.environ["AMPLIFIERD_DAEMON_SESSION_PATH"] = str(session_path)
 
     click.echo(
         f"amplifierd starting – host={effective_host} port={effective_port} "

--- a/src/amplifierd/cli.py
+++ b/src/amplifierd/cli.py
@@ -78,10 +78,25 @@ def serve(
     effective_port = port if port is not None else settings.port
     effective_log_level = log_level if log_level is not None else settings.log_level
 
+    # 1. Console logging (always available before daemon session dir)
     logging.basicConfig(
         level=_LOG_LEVELS.get(effective_log_level.lower(), logging.INFO),
         format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
     )
+
+    # 2. Create daemon session directory and route all output to serve.log
+    from amplifierd.daemon_session import create_session_dir, setup_session_log
+
+    session_path = create_session_dir(
+        settings.daemon_sessions_dir,
+        host=effective_host,
+        port=effective_port,
+        log_level=effective_log_level,
+    )
+    setup_session_log(session_path)
+
+    # Store the daemon session path in env so the app lifespan can pick it up
+    os.environ["_AMPLIFIERD_DAEMON_SESSION_PATH"] = str(session_path)
 
     click.echo(
         f"amplifierd starting – host={effective_host} port={effective_port} "

--- a/src/amplifierd/cli.py
+++ b/src/amplifierd/cli.py
@@ -84,25 +84,7 @@ def serve(
         format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
     )
 
-    # 2. Global rotating server.log — survives across individual daemon sessions
-    from logging.handlers import RotatingFileHandler
-
-    global_log_dir = settings.daemon_logs_dir
-    global_log_dir.mkdir(parents=True, exist_ok=True)
-    global_handler = RotatingFileHandler(
-        str(global_log_dir / "server.log"),
-        maxBytes=10_485_760,  # 10MB
-        backupCount=3,
-        encoding="utf-8",
-    )
-    global_handler.setFormatter(
-        logging.Formatter(
-            '{"ts":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","msg":"%(message)s"}'
-        )
-    )
-    logging.getLogger().addHandler(global_handler)
-
-    # 3. Create daemon session directory and route all output to serve.log
+    # 2. Create daemon session directory and route all output to serve.log
     from amplifierd.daemon_session import create_session_dir, setup_session_log
 
     session_path = create_session_dir(

--- a/src/amplifierd/config.py
+++ b/src/amplifierd/config.py
@@ -63,6 +63,7 @@ class DaemonSettings(BaseSettings):
     disabled_plugins: list[str] = Field(default_factory=list)
     bundles: dict[str, str] = Field(default_factory=lambda: dict(WELL_KNOWN_BUNDLES))
     default_bundle: str | None = "distro"
+    daemon_session_path: Path | None = None
 
     # Class-level storage for settings_dir (used by settings_customise_sources).
     # Not thread-safe: concurrent construction would race on this value.
@@ -70,8 +71,8 @@ class DaemonSettings(BaseSettings):
     _current_settings_dir: Path = _DEFAULT_HOME_DIR
 
     @property
-    def daemon_sessions_dir(self) -> Path:
-        """Per-daemon-run session logs: ``{home_dir}/sessions/``."""
+    def daemon_run_dir(self) -> Path:
+        """Per-daemon-run log directory: ``{home_dir}/sessions/``."""
         return self.home_dir / "sessions"
 
     @property

--- a/src/amplifierd/config.py
+++ b/src/amplifierd/config.py
@@ -76,11 +76,6 @@ class DaemonSettings(BaseSettings):
         return self.home_dir / "sessions"
 
     @property
-    def daemon_logs_dir(self) -> Path:
-        """Daemon-level log directory: ``{home_dir}/logs/``."""
-        return self.home_dir / "logs"
-
-    @property
     def plugins_dir(self) -> Path:
         """Plugin data directory: ``{home_dir}/plugins/``."""
         return self.home_dir / "plugins"

--- a/src/amplifierd/config.py
+++ b/src/amplifierd/config.py
@@ -12,7 +12,7 @@ from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_SETTINGS_DIR = Path.home() / ".amplifierd"
+_DEFAULT_HOME_DIR = Path.home() / ".amplifierd"
 
 WELL_KNOWN_BUNDLES: dict[str, str] = {
     "foundation": "git+https://github.com/microsoft/amplifier-foundation@main",
@@ -57,9 +57,8 @@ class DaemonSettings(BaseSettings):
     host: str = "127.0.0.1"
     port: int = 8410
     default_working_dir: Path | None = None
-    sessions_dir: Path = Field(
-        default_factory=lambda: Path.home() / ".amplifier" / "sessions"
-    )
+    home_dir: Path = Field(default_factory=lambda: _DEFAULT_HOME_DIR)
+    sessions_dir: Path = Field(default_factory=lambda: Path.home() / ".amplifier" / "sessions")
     log_level: str = "info"
     disabled_plugins: list[str] = Field(default_factory=list)
     bundles: dict[str, str] = Field(default_factory=lambda: dict(WELL_KNOWN_BUNDLES))
@@ -68,14 +67,34 @@ class DaemonSettings(BaseSettings):
     # Class-level storage for settings_dir (used by settings_customise_sources).
     # Not thread-safe: concurrent construction would race on this value.
     # Acceptable — this runs once at daemon startup, not on a hot path.
-    _current_settings_dir: Path = _DEFAULT_SETTINGS_DIR
+    _current_settings_dir: Path = _DEFAULT_HOME_DIR
+
+    @property
+    def daemon_sessions_dir(self) -> Path:
+        """Per-daemon-run session logs: ``{home_dir}/sessions/``."""
+        return self.home_dir / "sessions"
+
+    @property
+    def daemon_logs_dir(self) -> Path:
+        """Daemon-level log directory: ``{home_dir}/logs/``."""
+        return self.home_dir / "logs"
+
+    @property
+    def plugins_dir(self) -> Path:
+        """Plugin data directory: ``{home_dir}/plugins/``."""
+        return self.home_dir / "plugins"
+
+    @property
+    def run_dir(self) -> Path:
+        """Runtime directory for PID files: ``{home_dir}/run/``."""
+        return self.home_dir / "run"
 
     model_config = {"env_prefix": "AMPLIFIERD_"}
 
     def __init__(self, *, _settings_dir: Path | None = None, **kwargs: Any) -> None:
         # Temporarily set on class so settings_customise_sources can read it
         original = DaemonSettings._current_settings_dir
-        DaemonSettings._current_settings_dir = _settings_dir or _DEFAULT_SETTINGS_DIR
+        DaemonSettings._current_settings_dir = _settings_dir or _DEFAULT_HOME_DIR
         try:
             super().__init__(**kwargs)
         finally:

--- a/src/amplifierd/daemon_session.py
+++ b/src/amplifierd/daemon_session.py
@@ -20,7 +20,9 @@ import io
 import json
 import logging
 import os
+import shutil
 import sys
+import threading
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -39,33 +41,72 @@ class _TeeWriter(io.TextIOBase):
     lands in the per-session ``serve.log`` alongside Python logging output.
     """
 
-    def __init__(self, original: io.TextIOBase, log_path: Path) -> None:
+    def __init__(self, original: io.TextIOBase, log_file: io.TextIOBase) -> None:
+        super().__init__()
         self._original = original
-        self._log_file = log_path.open("a", encoding="utf-8")
+        self._log_file = log_file
+        self._lock = threading.Lock()
 
     def write(self, s: str) -> int:
-        self._original.write(s)
-        self._original.flush()
-        self._log_file.write(s)
-        self._log_file.flush()
+        with self._lock:
+            self._original.write(s)
+            self._original.flush()
+            try:
+                self._log_file.write(s)
+                self._log_file.flush()
+            except (OSError, ValueError):
+                pass
         return len(s)
 
     def flush(self) -> None:
-        self._original.flush()
-        self._log_file.flush()
+        with self._lock:
+            self._original.flush()
+            try:
+                self._log_file.flush()
+            except (OSError, ValueError):
+                pass
 
     def fileno(self) -> int:
-        return self._original.fileno()
+        raise io.UnsupportedOperation("fileno")
 
     def isatty(self) -> bool:
         return self._original.isatty()
+
+    def writable(self) -> bool:
+        return True
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self._original, "encoding", None) or "utf-8"
+
+    @property
+    def name(self) -> str:
+        return getattr(self._original, "name", "<tee>")
 
     def close(self) -> None:
         self._log_file.close()
 
 
+def prune_old_sessions(daemon_run_dir: Path, keep: int = 50) -> int:
+    """Remove oldest session directories, keeping the most recent `keep`."""
+    if not daemon_run_dir.exists():
+        return 0
+    sessions = sorted(
+        [p for p in daemon_run_dir.iterdir() if p.is_dir()],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    removed = 0
+    for old in sessions[keep:]:
+        shutil.rmtree(old, ignore_errors=True)
+        removed += 1
+    if removed:
+        logger.info("Pruned %d old daemon session(s)", removed)
+    return removed
+
+
 def create_session_dir(
-    daemon_sessions_dir: Path,
+    daemon_run_dir: Path,
     *,
     host: str,
     port: int,
@@ -75,7 +116,7 @@ def create_session_dir(
     """Create a new daemon session directory with ``meta.json``.
 
     Args:
-        daemon_sessions_dir: Parent directory (e.g. ``~/.amplifierd/sessions/``).
+        daemon_run_dir: Parent directory (e.g. ``~/.amplifierd/sessions/``).
         host: Bind address.
         port: Bind port.
         log_level: Effective log level.
@@ -84,9 +125,19 @@ def create_session_dir(
     Returns:
         Path to the created session directory.
     """
+    prune_old_sessions(daemon_run_dir)
+
     session_id = str(uuid.uuid4())
-    session_path = daemon_sessions_dir / session_id
+    session_path = daemon_run_dir / session_id
     session_path.mkdir(parents=True, exist_ok=True)
+    session_path.chmod(0o700)
+
+    try:
+        import amplifierd
+
+        version = amplifierd.__version__
+    except Exception:
+        version = "unknown"
 
     meta: dict[str, Any] = {
         "session_id": session_id,
@@ -96,23 +147,30 @@ def create_session_dir(
         "log_level": log_level,
         "start_time": datetime.now(tz=UTC).isoformat(),
         "plugins": plugins or [],
+        "status": "starting",
+        "version": version,
     }
 
     meta_path = session_path / META_FILENAME
     meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    meta_path.chmod(0o600)
 
     logger.info("Daemon session created: %s", session_path)
     return session_path
 
 
 def update_session_meta(session_path: Path, updates: dict[str, Any]) -> None:
-    """Merge updates into an existing ``meta.json``."""
+    """Merge updates into an existing ``meta.json`` atomically."""
     meta_path = session_path / META_FILENAME
-    if not meta_path.exists():
+    try:
+        existing = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
         return
-    existing = json.loads(meta_path.read_text(encoding="utf-8"))
     existing.update(updates)
-    meta_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    tmp_path = meta_path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    tmp_path.chmod(0o600)
+    os.replace(tmp_path, meta_path)
 
 
 def setup_session_log(session_path: Path, log_level: int = logging.DEBUG) -> None:
@@ -120,7 +178,7 @@ def setup_session_log(session_path: Path, log_level: int = logging.DEBUG) -> Non
 
     After calling this function:
 
-    1. All Python ``logging`` output goes to ``serve.log`` via a FileHandler
+    1. All Python ``logging`` output goes to ``serve.log`` via a StreamHandler
        on the root logger.
     2. All raw ``sys.stdout`` writes (uvicorn access logs, ``click.echo()``)
        go to ``serve.log`` via a TeeWriter.
@@ -134,18 +192,20 @@ def setup_session_log(session_path: Path, log_level: int = logging.DEBUG) -> Non
     """
     log_path = session_path / LOG_FILENAME
 
-    # 1. Python logging FileHandler → serve.log
-    handler = logging.FileHandler(str(log_path), encoding="utf-8")
+    # Open one shared file handle for all output
+    shared_file = open(log_path, "a", encoding="utf-8")  # noqa: SIM115
+    os.chmod(log_path, 0o600)
+
+    # 1. Python logging StreamHandler → serve.log (shared file handle)
+    handler = logging.StreamHandler(shared_file)
     handler.setLevel(log_level)
-    handler.setFormatter(
-        logging.Formatter("%(asctime)s %(levelname)-8s [%(name)s] %(message)s")
-    )
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s [%(name)s] %(message)s"))
     logging.getLogger().addHandler(handler)
 
     # 2. Tee stdout → serve.log
-    sys.stdout = _TeeWriter(sys.stdout, log_path)  # type: ignore[assignment]
+    sys.stdout = _TeeWriter(sys.stdout, shared_file)  # type: ignore[assignment]
 
     # 3. Tee stderr → serve.log
-    sys.stderr = _TeeWriter(sys.stderr, log_path)  # type: ignore[assignment]
+    sys.stderr = _TeeWriter(sys.stderr, shared_file)  # type: ignore[assignment]
 
     logger.info("Session log active: %s", log_path)

--- a/src/amplifierd/daemon_session.py
+++ b/src/amplifierd/daemon_session.py
@@ -1,0 +1,151 @@
+"""Daemon session directory — per-run server logs and metadata.
+
+Each ``amplifierd serve`` invocation creates a new session directory under
+``~/.amplifierd/sessions/{uuid}/`` containing:
+
+- ``meta.json`` — daemon run metadata (pid, port, host, start_time, plugins)
+- ``serve.log`` — all server output for this run (Python logging + stdout/stderr)
+
+This is distinct from Amplifier *conversation* sessions stored at
+``~/.amplifier/sessions/``, which hold ``transcript.jsonl`` and ``metadata.json``.
+
+Follows the pattern established by amplifier-distro's ``session_dir.py``.
+
+Related: https://github.com/microsoft/amplifier-distro/issues/176
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+META_FILENAME = "meta.json"
+LOG_FILENAME = "serve.log"
+
+
+class _TeeWriter(io.TextIOBase):
+    """File-like wrapper that writes to both the original stream and a log file.
+
+    Ensures all raw output (uvicorn access logs, tracebacks, print() calls)
+    lands in the per-session ``serve.log`` alongside Python logging output.
+    """
+
+    def __init__(self, original: io.TextIOBase, log_path: Path) -> None:
+        self._original = original
+        self._log_file = log_path.open("a", encoding="utf-8")
+
+    def write(self, s: str) -> int:
+        self._original.write(s)
+        self._original.flush()
+        self._log_file.write(s)
+        self._log_file.flush()
+        return len(s)
+
+    def flush(self) -> None:
+        self._original.flush()
+        self._log_file.flush()
+
+    def fileno(self) -> int:
+        return self._original.fileno()
+
+    def isatty(self) -> bool:
+        return self._original.isatty()
+
+    def close(self) -> None:
+        self._log_file.close()
+
+
+def create_session_dir(
+    daemon_sessions_dir: Path,
+    *,
+    host: str,
+    port: int,
+    log_level: str,
+    plugins: list[str] | None = None,
+) -> Path:
+    """Create a new daemon session directory with ``meta.json``.
+
+    Args:
+        daemon_sessions_dir: Parent directory (e.g. ``~/.amplifierd/sessions/``).
+        host: Bind address.
+        port: Bind port.
+        log_level: Effective log level.
+        plugins: List of discovered plugin names (updated later if not known yet).
+
+    Returns:
+        Path to the created session directory.
+    """
+    session_id = str(uuid.uuid4())
+    session_path = daemon_sessions_dir / session_id
+    session_path.mkdir(parents=True, exist_ok=True)
+
+    meta: dict[str, Any] = {
+        "session_id": session_id,
+        "pid": os.getpid(),
+        "host": host,
+        "port": port,
+        "log_level": log_level,
+        "start_time": datetime.now(tz=UTC).isoformat(),
+        "plugins": plugins or [],
+    }
+
+    meta_path = session_path / META_FILENAME
+    meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+
+    logger.info("Daemon session created: %s", session_path)
+    return session_path
+
+
+def update_session_meta(session_path: Path, updates: dict[str, Any]) -> None:
+    """Merge updates into an existing ``meta.json``."""
+    meta_path = session_path / META_FILENAME
+    if not meta_path.exists():
+        return
+    existing = json.loads(meta_path.read_text(encoding="utf-8"))
+    existing.update(updates)
+    meta_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+
+def setup_session_log(session_path: Path, log_level: int = logging.DEBUG) -> None:
+    """Attach a file handler and tee writers to capture all output for this run.
+
+    After calling this function:
+
+    1. All Python ``logging`` output goes to ``serve.log`` via a FileHandler
+       on the root logger.
+    2. All raw ``sys.stdout`` writes (uvicorn access logs, ``click.echo()``)
+       go to ``serve.log`` via a TeeWriter.
+    3. All raw ``sys.stderr`` writes (tracebacks, uvicorn errors) go to
+       ``serve.log`` via a TeeWriter.
+
+    Args:
+        session_path: The daemon session directory containing ``serve.log``.
+        log_level: Minimum level for the file handler (default: DEBUG to
+            capture everything regardless of console level).
+    """
+    log_path = session_path / LOG_FILENAME
+
+    # 1. Python logging FileHandler → serve.log
+    handler = logging.FileHandler(str(log_path), encoding="utf-8")
+    handler.setLevel(log_level)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)-8s [%(name)s] %(message)s")
+    )
+    logging.getLogger().addHandler(handler)
+
+    # 2. Tee stdout → serve.log
+    sys.stdout = _TeeWriter(sys.stdout, log_path)  # type: ignore[assignment]
+
+    # 3. Tee stderr → serve.log
+    sys.stderr = _TeeWriter(sys.stderr, log_path)  # type: ignore[assignment]
+
+    logger.info("Session log active: %s", log_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,8 @@ class TestServeDefaults:
         with (
             patch("uvicorn.run") as mock_run,
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
+            patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
+            patch("amplifierd.daemon_session.setup_session_log"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -80,6 +82,8 @@ class TestServeCLIOverrides:
         with (
             patch("uvicorn.run") as mock_run,
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
+            patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
+            patch("amplifierd.daemon_session.setup_session_log"),
         ):
             result = runner.invoke(
                 main, ["serve", "--host", "0.0.0.0", "--port", "9000", "--log-level", "debug"]
@@ -105,6 +109,8 @@ class TestServeCLIOverrides:
         with (
             patch("uvicorn.run") as mock_run,
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
+            patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
+            patch("amplifierd.daemon_session.setup_session_log"),
         ):
             result = runner.invoke(main, ["serve", "--reload"])
 
@@ -134,6 +140,8 @@ class TestServeLogging:
             patch("uvicorn.run"),
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("logging.basicConfig") as mock_basic_config,
+            patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
+            patch("amplifierd.daemon_session.setup_session_log"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -154,6 +162,8 @@ class TestServeLogging:
             patch("uvicorn.run"),
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("logging.basicConfig") as mock_basic_config,
+            patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
+            patch("amplifierd.daemon_session.setup_session_log"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -173,6 +183,8 @@ class TestServeLogging:
             patch("uvicorn.run"),
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("logging.basicConfig") as mock_basic_config,
+            patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
+            patch("amplifierd.daemon_session.setup_session_log"),
         ):
             result = runner.invoke(main, ["serve", "--log-level", "debug"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,14 @@ from click.testing import CliRunner, Result
 from amplifierd.cli import main
 
 
+@pytest.fixture(autouse=True)
+def _restore_root_handlers():
+    """Restore root logger handlers after each test to prevent handler leakage."""
+    original_handlers = logging.getLogger().handlers[:]
+    yield
+    logging.getLogger().handlers = original_handlers
+
+
 class TestServeHelp:
     """CliRunner invoke of main with ['serve', '--help'] should exit 0
     and output should contain '--port', '--host', '--reload'."""
@@ -55,6 +63,7 @@ class TestServeDefaults:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -84,6 +93,7 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(
                 main, ["serve", "--host", "0.0.0.0", "--port", "9000", "--log-level", "debug"]
@@ -111,6 +121,7 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve", "--reload"])
 
@@ -142,6 +153,7 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -164,6 +176,7 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -185,6 +198,7 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve", "--log-level", "debug"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,7 +63,6 @@ class TestServeDefaults:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -93,7 +92,6 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(
                 main, ["serve", "--host", "0.0.0.0", "--port", "9000", "--log-level", "debug"]
@@ -121,7 +119,6 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve", "--reload"])
 
@@ -153,7 +150,6 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -176,7 +172,6 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -198,7 +193,6 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve", "--log-level", "debug"])
 

--- a/tests/test_daemon_session.py
+++ b/tests/test_daemon_session.py
@@ -1,0 +1,191 @@
+"""Tests for daemon session directory and logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+class TestCreateSessionDir:
+    """Tests for create_session_dir: directory creation and meta.json."""
+
+    def test_creates_directory_and_meta(self, tmp_path: Path):
+        """A new UUID directory is created with a valid meta.json."""
+        from amplifierd.daemon_session import create_session_dir
+
+        session_path = create_session_dir(
+            tmp_path, host="127.0.0.1", port=8410, log_level="info"
+        )
+
+        assert session_path.exists()
+        assert session_path.parent == tmp_path
+
+        meta_path = session_path / "meta.json"
+        assert meta_path.exists()
+
+        meta = json.loads(meta_path.read_text())
+        assert meta["host"] == "127.0.0.1"
+        assert meta["port"] == 8410
+        assert meta["log_level"] == "info"
+        assert meta["pid"] > 0
+        assert meta["plugins"] == []
+        assert "session_id" in meta
+        assert "start_time" in meta
+
+    def test_session_id_is_directory_name(self, tmp_path: Path):
+        """The session_id in meta.json matches the directory name."""
+        from amplifierd.daemon_session import create_session_dir
+
+        session_path = create_session_dir(
+            tmp_path, host="0.0.0.0", port=9000, log_level="debug"
+        )
+
+        meta = json.loads((session_path / "meta.json").read_text())
+        assert meta["session_id"] == session_path.name
+
+    def test_creates_parent_directories(self, tmp_path: Path):
+        """Parent directories are created if they don't exist."""
+        from amplifierd.daemon_session import create_session_dir
+
+        deep_path = tmp_path / "a" / "b" / "sessions"
+        session_path = create_session_dir(
+            deep_path, host="127.0.0.1", port=8410, log_level="info"
+        )
+
+        assert session_path.exists()
+
+    def test_plugins_recorded_in_meta(self, tmp_path: Path):
+        """Plugin names are written to meta.json when provided."""
+        from amplifierd.daemon_session import create_session_dir
+
+        session_path = create_session_dir(
+            tmp_path,
+            host="127.0.0.1",
+            port=8410,
+            log_level="info",
+            plugins=["chat", "metrics"],
+        )
+
+        meta = json.loads((session_path / "meta.json").read_text())
+        assert meta["plugins"] == ["chat", "metrics"]
+
+    def test_each_call_creates_unique_directory(self, tmp_path: Path):
+        """Multiple calls create distinct session directories."""
+        from amplifierd.daemon_session import create_session_dir
+
+        kwargs = {"host": "127.0.0.1", "port": 8410, "log_level": "info"}
+        p1 = create_session_dir(tmp_path, **kwargs)
+        p2 = create_session_dir(tmp_path, **kwargs)
+
+        assert p1 != p2
+        assert p1.exists()
+        assert p2.exists()
+
+
+@pytest.mark.unit
+class TestUpdateSessionMeta:
+    """Tests for update_session_meta: merging updates into meta.json."""
+
+    def test_merges_updates(self, tmp_path: Path):
+        """Updates are merged into the existing meta.json."""
+        from amplifierd.daemon_session import create_session_dir, update_session_meta
+
+        session_path = create_session_dir(
+            tmp_path, host="127.0.0.1", port=8410, log_level="info"
+        )
+
+        update_session_meta(session_path, {"plugins": ["chat", "metrics"]})
+
+        meta = json.loads((session_path / "meta.json").read_text())
+        assert meta["plugins"] == ["chat", "metrics"]
+        # Original fields preserved
+        assert meta["host"] == "127.0.0.1"
+        assert meta["port"] == 8410
+
+    def test_noop_when_no_meta(self, tmp_path: Path):
+        """Does nothing when meta.json doesn't exist (no crash)."""
+        from amplifierd.daemon_session import update_session_meta
+
+        # tmp_path exists but has no meta.json
+        update_session_meta(tmp_path, {"plugins": ["chat"]})
+        assert not (tmp_path / "meta.json").exists()
+
+
+@pytest.mark.unit
+class TestSetupSessionLog:
+    """Tests for setup_session_log: FileHandler and TeeWriter wiring."""
+
+    def test_creates_serve_log(self, tmp_path: Path):
+        """setup_session_log creates a serve.log file."""
+        from amplifierd.daemon_session import setup_session_log
+
+        # Save originals to restore after test
+        orig_stdout = sys.stdout
+        orig_stderr = sys.stderr
+        orig_handlers = logging.getLogger().handlers[:]
+
+        try:
+            setup_session_log(tmp_path)
+
+            log_path = tmp_path / "serve.log"
+            assert log_path.exists()
+        finally:
+            # Restore originals
+            sys.stdout = orig_stdout
+            sys.stderr = orig_stderr
+            root = logging.getLogger()
+            root.handlers = orig_handlers
+
+    def test_python_logging_reaches_serve_log(self, tmp_path: Path):
+        """Python logging output is written to serve.log via the FileHandler."""
+        from amplifierd.daemon_session import setup_session_log
+
+        orig_stdout = sys.stdout
+        orig_stderr = sys.stderr
+        orig_handlers = logging.getLogger().handlers[:]
+
+        try:
+            setup_session_log(tmp_path)
+
+            test_logger = logging.getLogger("test.daemon_session")
+            test_logger.setLevel(logging.DEBUG)
+            test_logger.info("MARKER_LOG_LINE_12345")
+
+            # Flush all handlers
+            for h in logging.getLogger().handlers:
+                h.flush()
+
+            log_content = (tmp_path / "serve.log").read_text()
+            assert "MARKER_LOG_LINE_12345" in log_content
+        finally:
+            sys.stdout = orig_stdout
+            sys.stderr = orig_stderr
+            root = logging.getLogger()
+            root.handlers = orig_handlers
+
+    def test_stdout_teed_to_serve_log(self, tmp_path: Path):
+        """Raw sys.stdout writes are captured in serve.log."""
+        from amplifierd.daemon_session import setup_session_log
+
+        orig_stdout = sys.stdout
+        orig_stderr = sys.stderr
+        orig_handlers = logging.getLogger().handlers[:]
+
+        try:
+            setup_session_log(tmp_path)
+
+            sys.stdout.write("MARKER_STDOUT_67890\n")
+            sys.stdout.flush()
+
+            log_content = (tmp_path / "serve.log").read_text()
+            assert "MARKER_STDOUT_67890" in log_content
+        finally:
+            sys.stdout = orig_stdout
+            sys.stderr = orig_stderr
+            root = logging.getLogger()
+            root.handlers = orig_handlers

--- a/tests/test_daemon_session.py
+++ b/tests/test_daemon_session.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -18,9 +20,7 @@ class TestCreateSessionDir:
         """A new UUID directory is created with a valid meta.json."""
         from amplifierd.daemon_session import create_session_dir
 
-        session_path = create_session_dir(
-            tmp_path, host="127.0.0.1", port=8410, log_level="info"
-        )
+        session_path = create_session_dir(tmp_path, host="127.0.0.1", port=8410, log_level="info")
 
         assert session_path.exists()
         assert session_path.parent == tmp_path
@@ -41,9 +41,7 @@ class TestCreateSessionDir:
         """The session_id in meta.json matches the directory name."""
         from amplifierd.daemon_session import create_session_dir
 
-        session_path = create_session_dir(
-            tmp_path, host="0.0.0.0", port=9000, log_level="debug"
-        )
+        session_path = create_session_dir(tmp_path, host="0.0.0.0", port=9000, log_level="debug")
 
         meta = json.loads((session_path / "meta.json").read_text())
         assert meta["session_id"] == session_path.name
@@ -53,9 +51,7 @@ class TestCreateSessionDir:
         from amplifierd.daemon_session import create_session_dir
 
         deep_path = tmp_path / "a" / "b" / "sessions"
-        session_path = create_session_dir(
-            deep_path, host="127.0.0.1", port=8410, log_level="info"
-        )
+        session_path = create_session_dir(deep_path, host="127.0.0.1", port=8410, log_level="info")
 
         assert session_path.exists()
 
@@ -86,6 +82,24 @@ class TestCreateSessionDir:
         assert p1.exists()
         assert p2.exists()
 
+    def test_meta_contains_status_starting(self, tmp_path: Path):
+        """meta.json includes status='starting' immediately after creation."""
+        from amplifierd.daemon_session import create_session_dir
+
+        session_path = create_session_dir(tmp_path, host="127.0.0.1", port=8410, log_level="info")
+
+        meta = json.loads((session_path / "meta.json").read_text())
+        assert meta["status"] == "starting"
+
+    def test_meta_contains_version_field(self, tmp_path: Path):
+        """meta.json includes a 'version' key (even if 'unknown')."""
+        from amplifierd.daemon_session import create_session_dir
+
+        session_path = create_session_dir(tmp_path, host="127.0.0.1", port=8410, log_level="info")
+
+        meta = json.loads((session_path / "meta.json").read_text())
+        assert "version" in meta
+
 
 @pytest.mark.unit
 class TestUpdateSessionMeta:
@@ -95,9 +109,7 @@ class TestUpdateSessionMeta:
         """Updates are merged into the existing meta.json."""
         from amplifierd.daemon_session import create_session_dir, update_session_meta
 
-        session_path = create_session_dir(
-            tmp_path, host="127.0.0.1", port=8410, log_level="info"
-        )
+        session_path = create_session_dir(tmp_path, host="127.0.0.1", port=8410, log_level="info")
 
         update_session_meta(session_path, {"plugins": ["chat", "metrics"]})
 
@@ -114,6 +126,154 @@ class TestUpdateSessionMeta:
         # tmp_path exists but has no meta.json
         update_session_meta(tmp_path, {"plugins": ["chat"]})
         assert not (tmp_path / "meta.json").exists()
+
+    def test_noop_when_meta_is_corrupt(self, tmp_path: Path):
+        """Does nothing when meta.json contains invalid JSON (no crash)."""
+        from amplifierd.daemon_session import update_session_meta
+
+        meta_path = tmp_path / "meta.json"
+        meta_path.write_text("not valid json", encoding="utf-8")
+
+        # Should not raise
+        update_session_meta(tmp_path, {"status": "running"})
+
+        # File is left as-is (atomic replace only happens on success)
+        assert meta_path.read_text() == "not valid json"
+
+    def test_atomic_write_uses_tmp_then_replace(self, tmp_path: Path):
+        """Update writes to .tmp first then renames (no .tmp left behind)."""
+        from amplifierd.daemon_session import create_session_dir, update_session_meta
+
+        session_path = create_session_dir(tmp_path, host="127.0.0.1", port=8410, log_level="info")
+        update_session_meta(session_path, {"status": "running"})
+
+        # No stale .tmp file
+        assert not (session_path / "meta.tmp").exists()
+
+        meta = json.loads((session_path / "meta.json").read_text())
+        assert meta["status"] == "running"
+
+
+@pytest.mark.unit
+class TestPruneOldSessions:
+    """Tests for prune_old_sessions: removing oldest session directories."""
+
+    def test_prunes_excess_sessions(self, tmp_path: Path):
+        """Keeps only the most recent `keep` dirs; removes older ones."""
+        from amplifierd.daemon_session import prune_old_sessions
+
+        # Create 55 directories with distinct mtimes
+        for i in range(55):
+            d = tmp_path / f"session_{i:02d}"
+            d.mkdir()
+            mtime = 1_000_000 + i
+            os.utime(d, (mtime, mtime))
+
+        removed = prune_old_sessions(tmp_path, keep=50)
+
+        assert removed == 5
+        remaining = [p.name for p in tmp_path.iterdir() if p.is_dir()]
+        assert len(remaining) == 50
+        # Oldest five (session_00..04) should be gone; newest (session_05..54) kept
+        for i in range(5):
+            assert f"session_{i:02d}" not in remaining
+        for i in range(5, 55):
+            assert f"session_{i:02d}" in remaining
+
+    def test_noop_when_dir_missing(self, tmp_path: Path):
+        """Returns 0 without error when the directory doesn't exist."""
+        from amplifierd.daemon_session import prune_old_sessions
+
+        missing = tmp_path / "nonexistent"
+        removed = prune_old_sessions(missing)
+        assert removed == 0
+
+    def test_noop_when_under_limit(self, tmp_path: Path):
+        """Does not remove anything when count is within the keep limit."""
+        from amplifierd.daemon_session import prune_old_sessions
+
+        for i in range(5):
+            (tmp_path / f"session_{i}").mkdir()
+
+        removed = prune_old_sessions(tmp_path, keep=50)
+        assert removed == 0
+        assert len(list(tmp_path.iterdir())) == 5
+
+
+@pytest.mark.unit
+class TestTeeWriterRobustness:
+    """Tests for _TeeWriter: thread safety, error resilience, interface."""
+
+    def test_write_survives_closed_log_file(self, tmp_path: Path):
+        """write() does not raise even when the log file is already closed."""
+        from amplifierd.daemon_session import _TeeWriter
+
+        captured = io.StringIO()
+        log_file = open(tmp_path / "test.log", "w", encoding="utf-8")
+        tee = _TeeWriter(captured, log_file)
+        log_file.close()  # Force an OSError on next write
+
+        # Must not raise; original stream still receives the data
+        tee.write("hello")
+        assert "hello" in captured.getvalue()
+
+    def test_flush_survives_closed_log_file(self, tmp_path: Path):
+        """flush() does not raise even when the log file is already closed."""
+        from amplifierd.daemon_session import _TeeWriter
+
+        captured = io.StringIO()
+        log_file = open(tmp_path / "test.log", "w", encoding="utf-8")
+        tee = _TeeWriter(captured, log_file)
+        log_file.close()
+
+        tee.flush()  # Should not raise
+
+    def test_writable_returns_true(self, tmp_path: Path):
+        """writable() always returns True."""
+        from amplifierd.daemon_session import _TeeWriter
+
+        captured = io.StringIO()
+        log_file = open(tmp_path / "test.log", "w", encoding="utf-8")
+        tee = _TeeWriter(captured, log_file)
+
+        assert tee.writable() is True
+        log_file.close()
+
+    def test_fileno_raises_unsupported(self, tmp_path: Path):
+        """fileno() raises io.UnsupportedOperation."""
+        from amplifierd.daemon_session import _TeeWriter
+
+        captured = io.StringIO()
+        log_file = open(tmp_path / "test.log", "w", encoding="utf-8")
+        tee = _TeeWriter(captured, log_file)
+
+        with pytest.raises(io.UnsupportedOperation):
+            tee.fileno()
+
+        log_file.close()
+
+    def test_encoding_property(self, tmp_path: Path):
+        """encoding property delegates to the original stream."""
+        from amplifierd.daemon_session import _TeeWriter
+
+        original = io.StringIO()
+        log_file = open(tmp_path / "test.log", "w", encoding="utf-8")
+        tee = _TeeWriter(original, log_file)
+
+        # StringIO has no encoding attribute, so falls back to 'utf-8'
+        assert tee.encoding == "utf-8"
+        log_file.close()
+
+    def test_name_property(self, tmp_path: Path):
+        """name property falls back to '<tee>' when original has no name."""
+        from amplifierd.daemon_session import _TeeWriter
+
+        original = io.StringIO()
+        log_file = open(tmp_path / "test.log", "w", encoding="utf-8")
+        tee = _TeeWriter(original, log_file)
+
+        assert tee.name == "<tee>"
+        log_file.close()
 
 
 @pytest.mark.unit
@@ -184,6 +344,28 @@ class TestSetupSessionLog:
 
             log_content = (tmp_path / "serve.log").read_text()
             assert "MARKER_STDOUT_67890" in log_content
+        finally:
+            sys.stdout = orig_stdout
+            sys.stderr = orig_stderr
+            root = logging.getLogger()
+            root.handlers = orig_handlers
+
+    def test_stderr_teed_to_serve_log(self, tmp_path: Path):
+        """Raw sys.stderr writes are captured in serve.log."""
+        from amplifierd.daemon_session import setup_session_log
+
+        orig_stdout = sys.stdout
+        orig_stderr = sys.stderr
+        orig_handlers = logging.getLogger().handlers[:]
+
+        try:
+            setup_session_log(tmp_path)
+
+            sys.stderr.write("MARKER_STDERR_99999\n")
+            sys.stderr.flush()
+
+            log_content = (tmp_path / "serve.log").read_text()
+            assert "MARKER_STDERR_99999" in log_content
         finally:
             sys.stdout = orig_stdout
             sys.stderr = orig_stderr


### PR DESCRIPTION
Each `amplifierd serve` invocation now creates a daemon session directory under `~/.amplifierd/sessions/{uuid}/` containing:
- `meta.json` — daemon run metadata (pid, port, host, start_time, log_level, plugins, version, status)
- `serve.log` — all server output for this run (Python logging + stdout/stderr via TeeWriter)

This is distinct from conversation session data (`transcript.jsonl`, `metadata.json`) which remains at `~/.amplifier/sessions/`. Follows the pattern established by amplifier-distro's `session_dir.py`.

## Changes

**New: `src/amplifierd/daemon_session.py`**
- `create_session_dir()` — creates per-run dir with `meta.json`
- `setup_session_log()` — wires FileHandler + TeeWriter to capture all output
- `update_session_meta()` — atomic read-modify-write for `meta.json`
- `prune_old_sessions()` — startup cleanup (keeps 50 most recent)
- `_TeeWriter` — thread-safe, error-resilient stdout/stderr wrapper

**Modified: `src/amplifierd/config.py`**
- Added `home_dir`, `daemon_session_path` settings
- Added derived properties: `daemon_run_dir`, `plugins_dir`, `run_dir`

**Modified: `src/amplifierd/cli.py`**
- Wired daemon session creation + log routing into `serve()` startup

**Modified: `src/amplifierd/app.py`**
- Reads `daemon_session_path` from settings (not raw env var)
- Guards `setup_session_log()` in lifespan for `--reload` worker processes
- Writes `status: running` on startup, `status: stopped` + `end_time` on shutdown
- Updates `meta.json` with discovered plugin names

**Tests: 24 new tests** covering directory creation, meta.json, serve.log routing, TeeWriter robustness, pruning, atomic writes

## Test Results
441 passed, 2 failed (pre-existing on main, unrelated)

Related: https://github.com/microsoft/amplifier-distro/issues/176