### PR TITLE
feat: adopt CLI projects/ session layout for parity

### DIFF
--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -80,12 +80,11 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         logger.warning("Failed to create BundleRegistry; starting without it", exc_info=True)
         app.state.bundle_registry = None
 
-    sessions_dir = settings.sessions_dir
     app.state.session_manager = SessionManager(
         event_bus=app.state.event_bus,
         settings=settings,
         bundle_registry=app.state.bundle_registry,
-        sessions_dir=sessions_dir,
+        projects_dir=settings.projects_dir,
     )
 
     # Plugin discovery — resilient

--- a/src/amplifierd/cli.py
+++ b/src/amplifierd/cli.py
@@ -84,7 +84,25 @@ def serve(
         format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
     )
 
-    # 2. Create daemon session directory and route all output to serve.log
+    # 2. Global rotating server.log — survives across individual daemon sessions
+    from logging.handlers import RotatingFileHandler
+
+    global_log_dir = settings.daemon_logs_dir
+    global_log_dir.mkdir(parents=True, exist_ok=True)
+    global_handler = RotatingFileHandler(
+        str(global_log_dir / "server.log"),
+        maxBytes=10_485_760,  # 10MB
+        backupCount=3,
+        encoding="utf-8",
+    )
+    global_handler.setFormatter(
+        logging.Formatter(
+            '{"ts":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","msg":"%(message)s"}'
+        )
+    )
+    logging.getLogger().addHandler(global_handler)
+
+    # 3. Create daemon session directory and route all output to serve.log
     from amplifierd.daemon_session import create_session_dir, setup_session_log
 
     session_path = create_session_dir(

--- a/src/amplifierd/config.py
+++ b/src/amplifierd/config.py
@@ -51,6 +51,15 @@ class JsonFileSettingsSource(PydanticBaseSettingsSource):
             return {}
 
 
+def cwd_to_slug(working_dir: str) -> str:
+    """Convert a working directory path to a project slug (same convention as Amplifier CLI).
+
+    Replaces every ``/`` with ``-`` so e.g. ``/home/sam/myproject`` becomes
+    ``-home-sam-myproject``.
+    """
+    return str(working_dir).replace("/", "-")
+
+
 class DaemonSettings(BaseSettings):
     """Core daemon settings loaded from env vars, JSON file, and defaults."""
 
@@ -58,7 +67,9 @@ class DaemonSettings(BaseSettings):
     port: int = 8410
     default_working_dir: Path | None = None
     home_dir: Path = Field(default_factory=lambda: _DEFAULT_HOME_DIR)
-    sessions_dir: Path = Field(default_factory=lambda: Path.home() / ".amplifier" / "sessions")
+    projects_dir: Path = Field(
+        default_factory=lambda: Path.home() / ".amplifier" / "projects"
+    )
     log_level: str = "info"
     disabled_plugins: list[str] = Field(default_factory=list)
     bundles: dict[str, str] = Field(default_factory=lambda: dict(WELL_KNOWN_BUNDLES))
@@ -74,6 +85,11 @@ class DaemonSettings(BaseSettings):
     def daemon_run_dir(self) -> Path:
         """Per-daemon-run log directory: ``{home_dir}/sessions/``."""
         return self.home_dir / "sessions"
+
+    @property
+    def daemon_logs_dir(self) -> Path:
+        """Daemon-level log directory: ``{home_dir}/logs/``."""
+        return self.home_dir / "logs"
 
     @property
     def plugins_dir(self) -> Path:

--- a/src/amplifierd/routes/sessions.py
+++ b/src/amplifierd/routes/sessions.py
@@ -211,12 +211,22 @@ async def patch_session(
     if body.working_dir is not None:
         metadata_updates["working_dir"] = body.working_dir
 
-    if metadata_updates and manager.sessions_dir:
-        session_dir = manager.sessions_dir / session_id
-        if session_dir.exists():
+    if metadata_updates:
+        session_dir = manager.resolve_session_dir(session_id)
+        if session_dir is not None:
             from amplifierd.persistence import write_metadata
 
             write_metadata(session_dir, metadata_updates)
+
+    # Publish session_renamed event if name changed
+    if body.name is not None and handle is not None:
+        event_bus = getattr(request.app.state, "event_bus", None)
+        if event_bus is not None:
+            event_bus.publish(
+                session_id=session_id,
+                event_name="session_renamed",
+                data={"session_id": session_id, "name": body.name},
+            )
 
     if handle is not None:
         summary = _summarize(handle)
@@ -226,7 +236,7 @@ async def patch_session(
         ).model_dump(exclude_none=True)
 
     # Disk-only session — return minimal response
-    if manager.sessions_dir and (manager.sessions_dir / session_id).exists():
+    if manager.resolve_session_dir(session_id) is not None:
         return {"session_id": session_id, "updated": True}
 
     detail = ProblemDetail(
@@ -482,17 +492,19 @@ async def list_forks(request: Request, session_id: str) -> dict[str, Any]:
 async def get_transcript(request: Request, session_id: str) -> dict:
     """Load conversation transcript for a session from transcript.jsonl."""
     manager: SessionManager = request.app.state.session_manager
-    sessions_dir = manager.sessions_dir
-    if not sessions_dir:
+
+    session_dir = manager.resolve_session_dir(session_id)
+    if session_dir is None:
         detail = ProblemDetail(
             type=ErrorTypeURI.SESSION_NOT_FOUND,
             title="Session Not Found",
             status=404,
-            detail="Session persistence not configured",
+            detail=f"No transcript for session '{session_id}'",
             instance=str(request.url.path),
         )
         raise HTTPException(status_code=404, detail=detail.model_dump(exclude_none=True))
-    transcript_path = sessions_dir / session_id / "transcript.jsonl"
+
+    transcript_path = session_dir / "transcript.jsonl"
     if not transcript_path.exists():
         detail = ProblemDetail(
             type=ErrorTypeURI.SESSION_NOT_FOUND,
@@ -720,13 +732,12 @@ async def update_metadata(request: Request, session_id: str, body: dict) -> dict
     """Update metadata for a session (active or inactive on disk)."""
     manager: SessionManager = request.app.state.session_manager
 
-    if manager.sessions_dir:
-        session_dir = manager.sessions_dir / session_id
-        if session_dir.exists():
-            from amplifierd.persistence import write_metadata
+    session_dir = manager.resolve_session_dir(session_id)
+    if session_dir is not None:
+        from amplifierd.persistence import write_metadata
 
-            write_metadata(session_dir, body)
-            return {"updated": True, "session_id": session_id}
+        write_metadata(session_dir, body)
+        return {"updated": True, "session_id": session_id}
 
     detail = ProblemDetail(
         type=ErrorTypeURI.SESSION_NOT_FOUND,

--- a/src/amplifierd/state/session_index.py
+++ b/src/amplifierd/state/session_index.py
@@ -18,6 +18,7 @@ class SessionIndexEntry:
     created_at: str
     last_activity: str
     parent_session_id: str | None = None
+    project_id: str = ""
 
 
 _ENTRY_FIELDS = {f.name for f in dc_fields(SessionIndexEntry)}
@@ -65,35 +66,47 @@ class SessionIndex:
         try:
             data = json.loads(path.read_text())
             for item in data:
+                # Tolerate old entries that pre-date project_id field
+                item.setdefault("project_id", "")
                 index._entries[item["session_id"]] = SessionIndexEntry(**item)
         except (json.JSONDecodeError, KeyError, TypeError, ValueError):
             logger.warning("Session index corrupted at %s, starting empty", path)
         return index
 
     @classmethod
-    def rebuild(cls, sessions_dir: Path) -> SessionIndex:
-        index_path = sessions_dir / "index.json"
+    def rebuild(cls, projects_dir: Path) -> SessionIndex:
+        """Rebuild index by walking projects_dir/<project>/ sessions/<session>/ layout."""
+        index_path = projects_dir / "index.json"
         index = cls(index_path)
-        if not sessions_dir.exists():
+        if not projects_dir.exists():
             return index
-        for sdir in sessions_dir.iterdir():
-            if not sdir.is_dir():
+        for project_dir in projects_dir.iterdir():
+            if not project_dir.is_dir():
                 continue
-            meta_path = sdir / "metadata.json"
-            if not meta_path.exists():
+            sessions_subdir = project_dir / "sessions"
+            if not sessions_subdir.is_dir():
                 continue
-            try:
-                meta = json.loads(meta_path.read_text())
-                index.add(
-                    SessionIndexEntry(
-                        session_id=sdir.name,
-                        status=meta.get("status", "completed"),
-                        bundle=meta.get("bundle", "unknown"),
-                        created_at=meta.get("created_at", ""),
-                        last_activity=meta.get("last_activity", meta.get("created_at", "")),
-                        parent_session_id=meta.get("parent_session_id"),
+            for session_dir in sessions_subdir.iterdir():
+                if not session_dir.is_dir():
+                    continue
+                meta_path = session_dir / "metadata.json"
+                if not meta_path.exists():
+                    continue
+                try:
+                    meta = json.loads(meta_path.read_text())
+                    index.add(
+                        SessionIndexEntry(
+                            session_id=session_dir.name,
+                            status=meta.get("status", "completed"),
+                            bundle=meta.get("bundle", "unknown"),
+                            created_at=meta.get("created_at", ""),
+                            last_activity=meta.get(
+                                "last_activity", meta.get("created_at", "")
+                            ),
+                            parent_session_id=meta.get("parent_session_id"),
+                            project_id=project_dir.name,
+                        )
                     )
-                )
-            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-                logger.warning("Skipping unreadable session dir: %s", sdir)
+                except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+                    logger.warning("Skipping unreadable session dir: %s", session_dir)
         return index

--- a/src/amplifierd/state/session_manager.py
+++ b/src/amplifierd/state/session_manager.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from amplifierd.config import DaemonSettings
+from amplifierd.config import DaemonSettings, cwd_to_slug
 from amplifierd.state.event_bus import EventBus
 from amplifierd.state.session_handle import SessionHandle
 from amplifierd.state.session_index import SessionIndex, SessionIndexEntry
@@ -33,23 +33,27 @@ class SessionManager:
         event_bus: EventBus,
         settings: DaemonSettings,
         bundle_registry: Any = None,
+        projects_dir: Path | None = None,
+        # Backward-compat alias: callers that still pass sessions_dir= are
+        # transparently redirected to projects_dir.
         sessions_dir: Path | None = None,
     ) -> None:
         self._sessions: dict[str, SessionHandle] = {}
         self._event_bus = event_bus
         self._settings = settings
         self._bundle_registry = bundle_registry
-        self._sessions_dir = sessions_dir
+        # Prefer the explicit projects_dir; fall back to the legacy alias.
+        self._projects_dir: Path | None = projects_dir or sessions_dir
         self._index: SessionIndex | None = None
-        if sessions_dir:
-            index_path = sessions_dir / "index.json"
+        if self._projects_dir:
+            index_path = self._projects_dir / "index.json"
             if index_path.exists():
                 try:
                     self._index = SessionIndex.load(index_path)
                 except Exception:
-                    self._index = SessionIndex.rebuild(sessions_dir)
+                    self._index = SessionIndex.rebuild(self._projects_dir)
             else:
-                self._index = SessionIndex.rebuild(sessions_dir)
+                self._index = SessionIndex.rebuild(self._projects_dir)
 
     @property
     def event_bus(self) -> EventBus:
@@ -60,8 +64,15 @@ class SessionManager:
         return self._settings
 
     @property
+    def projects_dir(self) -> Path | None:
+        """Root directory for all projects: ``~/.amplifier/projects/``."""
+        return self._projects_dir
+
+    # Backward-compat alias used by older routes / tests
+    @property
     def sessions_dir(self) -> Path | None:
-        return self._sessions_dir
+        """Deprecated: use ``projects_dir`` instead."""
+        return self._projects_dir
 
     def resolve_working_dir(self, request_working_dir: str | None) -> str:
         """Resolve working directory using the fallback chain:
@@ -78,6 +89,41 @@ class SessionManager:
             return str(self._settings.default_working_dir)
         return str(Path.home())
 
+    def _find_session_dir(self, session_id: str) -> Path | None:
+        """Find a session directory by scanning all projects.
+
+        Search order:
+        1. Index entry with a known project_id (fast path).
+        2. Full directory scan of all projects (fallback).
+        """
+        if not self._projects_dir:
+            return None
+
+        # Fast path via index
+        if self._index:
+            entry = self._index.get(session_id)
+            if entry and entry.project_id:
+                candidate = (
+                    self._projects_dir / entry.project_id / "sessions" / session_id
+                )
+                if candidate.exists():
+                    return candidate
+
+        # Fallback: scan all project directories
+        if not self._projects_dir.exists():
+            return None
+        for project_dir in self._projects_dir.iterdir():
+            if not project_dir.is_dir():
+                continue
+            candidate = project_dir / "sessions" / session_id
+            if candidate.exists():
+                return candidate
+        return None
+
+    def resolve_session_dir(self, session_id: str) -> Path | None:
+        """Public helper for routes: find the on-disk directory for *session_id*."""
+        return self._find_session_dir(session_id)
+
     def register(
         self,
         *,
@@ -85,6 +131,7 @@ class SessionManager:
         prepared_bundle: Any | None,  # PreparedBundle
         bundle_name: str,
         working_dir: str | None = None,
+        project_id: str = "",
     ) -> SessionHandle:
         """Register a pre-created session and wrap it in a SessionHandle."""
         session_id: str = session.session_id
@@ -109,6 +156,7 @@ class SessionManager:
                     created_at=handle.created_at.isoformat(),
                     last_activity=handle.last_activity.isoformat(),
                     parent_session_id=getattr(session, "parent_id", None),
+                    project_id=project_id,
                 )
             )
             self._index.save()
@@ -204,10 +252,13 @@ class SessionManager:
         session = await prepared.create_session()
 
         # Register transcript/metadata persistence hooks
-        if self._sessions_dir:
+        if self._projects_dir:
             from amplifierd.persistence import register_persistence_hooks
 
-            session_dir = self._sessions_dir / session.session_id
+            slug = cwd_to_slug(wd)
+            project_dir = self._projects_dir / slug
+            sessions_subdir = project_dir / "sessions"
+            session_dir = sessions_subdir / session.session_id
             session_dir.mkdir(parents=True, exist_ok=True)
             info_path = session_dir / "session-info.json"
             if not info_path.exists():
@@ -222,6 +273,8 @@ class SessionManager:
                     "working_dir": str(wd),
                 },
             )
+        else:
+            slug = ""
 
         # Register spawn capability so delegate tool can spawn sub-sessions
         try:
@@ -236,16 +289,16 @@ class SessionManager:
             prepared_bundle=prepared,
             bundle_name=bundle_name or bundle_uri or "unknown",
             working_dir=wd,
+            project_id=slug,
         )
         return handle
 
     async def resume(self, session_id: str) -> SessionHandle:
         """Resume a session from disk after server restart.
 
-        Loads the transcript from ``{sessions_dir}/{session_id}/transcript.jsonl``,
-        handles orphaned tool calls, creates a fresh session with
-        ``is_resumed=True``, and injects the transcript into the new
-        session's context.
+        Loads the transcript from the session directory, handles orphaned tool
+        calls, creates a fresh session with ``is_resumed=True``, and injects
+        the transcript into the new session's context.
 
         Args:
             session_id: ID of the session to resume.
@@ -254,7 +307,7 @@ class SessionManager:
             The resumed SessionHandle.
 
         Raises:
-            ValueError: If sessions_dir is not configured.
+            ValueError: If projects_dir is not configured.
             RuntimeError: If BundleRegistry is not available.
             FileNotFoundError: If session directory or transcript not found.
         """
@@ -263,13 +316,13 @@ class SessionManager:
         if existing is not None:
             return existing
 
-        if not self._sessions_dir:
-            raise ValueError("Session persistence not configured (sessions_dir is None)")
+        if not self._projects_dir:
+            raise ValueError("Session persistence not configured (projects_dir is None)")
         if not self._bundle_registry:
             raise RuntimeError("BundleRegistry not available")
 
-        session_dir = self._sessions_dir / session_id
-        if not session_dir.exists():
+        session_dir = self._find_session_dir(session_id)
+        if session_dir is None or not session_dir.exists():
             raise FileNotFoundError(f"No session directory for {session_id}")
 
         # 1. Load transcript from disk (offload sync I/O to thread)
@@ -345,12 +398,16 @@ class SessionManager:
         except (ImportError, Exception):  # noqa: BLE001
             logger.debug("Spawn capability registration skipped", exc_info=True)
 
+        # Determine project_id for index entry
+        project_id = session_dir.parent.parent.name if session_dir.parent.name == "sessions" else ""
+
         # 8. Register in SessionManager
         handle = self.register(
             session=session,
             prepared_bundle=prepared,
             bundle_name=bundle_name,
             working_dir=working_dir,
+            project_id=project_id,
         )
         logger.info(
             "Session %s resumed (%d messages restored)",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,7 @@ class TestServeDefaults:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -92,6 +93,7 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(
                 main, ["serve", "--host", "0.0.0.0", "--port", "9000", "--log-level", "debug"]
@@ -119,6 +121,7 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve", "--reload"])
 
@@ -150,6 +153,7 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -172,6 +176,7 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -193,6 +198,7 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("logging.handlers.RotatingFileHandler"),
         ):
             result = runner.invoke(main, ["serve", "--log-level", "debug"])
 

--- a/tests/test_session_history.py
+++ b/tests/test_session_history.py
@@ -15,28 +15,32 @@ from amplifierd.state.session_manager import SessionManager
 
 @pytest.fixture()
 def session_manager_with_index(tmp_path):
-    """Factory: returns a callable that creates a SessionManager with index support."""
+    """Factory: returns a callable that creates a SessionManager with projects_dir support."""
 
-    def _factory(sessions_dir: Path) -> SessionManager:
+    def _factory(projects_dir: Path) -> SessionManager:
         settings = DaemonSettings()
         event_bus = EventBus()
         return SessionManager(
             event_bus=event_bus,
             settings=settings,
-            sessions_dir=sessions_dir,
+            projects_dir=projects_dir,
         )
 
     return _factory
 
 
+def _make_session_dir(projects_dir: Path, session_id: str, project_slug: str = "-home-user-proj") -> Path:
+    """Helper: create nested projects/<slug>/sessions/<sid>/ directory."""
+    sdir = projects_dir / project_slug / "sessions" / session_id
+    sdir.mkdir(parents=True, exist_ok=True)
+    return sdir
+
+
 def test_list_sessions_includes_historical(tmp_path, session_manager_with_index):
     """Historical sessions from index appear in list_sessions()."""
-    # Pre-populate sessions_dir with a historical session (metadata.json only, no in-memory handle)
-    sessions_dir = tmp_path / "sessions"
-    sessions_dir.mkdir(parents=True)
+    projects_dir = tmp_path / "projects"
     sid = "historical-abc"
-    sdir = sessions_dir / sid
-    sdir.mkdir()
+    sdir = _make_session_dir(projects_dir, sid)
     (sdir / "metadata.json").write_text(
         json.dumps(
             {
@@ -47,7 +51,7 @@ def test_list_sessions_includes_historical(tmp_path, session_manager_with_index)
         )
     )
 
-    manager = session_manager_with_index(sessions_dir)
+    manager = session_manager_with_index(projects_dir)
     sessions = manager.list_sessions()
 
     sids = [s.session_id if hasattr(s, "session_id") else s["session_id"] for s in sessions]
@@ -56,14 +60,14 @@ def test_list_sessions_includes_historical(tmp_path, session_manager_with_index)
 
 def test_list_sessions_active_takes_priority_over_historical(tmp_path, session_manager_with_index):
     """An active in-memory session is not duplicated by the index."""
-    sessions_dir = tmp_path / "sessions"
-    sessions_dir.mkdir(parents=True)
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir(parents=True)
 
     sid = "active-and-indexed"
-    # Put it in the index
+    # Put it in the index (placed at projects_dir level)
     from amplifierd.state.session_index import SessionIndex, SessionIndexEntry
 
-    index = SessionIndex(sessions_dir / "index.json")
+    index = SessionIndex(projects_dir / "index.json")
     index.add(
         SessionIndexEntry(
             session_id=sid,
@@ -71,11 +75,12 @@ def test_list_sessions_active_takes_priority_over_historical(tmp_path, session_m
             bundle="some-bundle",
             created_at="2026-03-01T10:00:00Z",
             last_activity="2026-03-01T10:00:00Z",
+            project_id="-home-user-proj",
         )
     )
     index.save()
 
-    manager = session_manager_with_index(sessions_dir)
+    manager = session_manager_with_index(projects_dir)
 
     # Register the same session as active
     mock_session = MagicMock()
@@ -91,10 +96,10 @@ def test_list_sessions_active_takes_priority_over_historical(tmp_path, session_m
 
 def test_register_adds_entry_to_index(tmp_path, session_manager_with_index):
     """Registering a new session writes it into the SessionIndex."""
-    sessions_dir = tmp_path / "sessions"
-    sessions_dir.mkdir(parents=True)
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir(parents=True)
 
-    manager = session_manager_with_index(sessions_dir)
+    manager = session_manager_with_index(projects_dir)
 
     mock_session = MagicMock()
     mock_session.session_id = "new-session-xyz"
@@ -112,10 +117,10 @@ async def test_destroy_updates_index_status(tmp_path, session_manager_with_index
     """Destroying a session updates its status in the index."""
     from unittest.mock import AsyncMock
 
-    sessions_dir = tmp_path / "sessions"
-    sessions_dir.mkdir(parents=True)
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir(parents=True)
 
-    manager = session_manager_with_index(sessions_dir)
+    manager = session_manager_with_index(projects_dir)
 
     mock_session = MagicMock()
     mock_session.session_id = "to-destroy-idx"

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -38,13 +38,16 @@ def test_atomic_write(tmp_path):
     assert (tmp_path / "index.json").exists()
 
 
-def test_rebuild_from_session_dirs(tmp_path):
-    """Rebuild index by scanning session directories."""
-    sessions_dir = tmp_path / "sessions"
+def test_rebuild_from_project_layout(tmp_path):
+    """Rebuild index by scanning projects/<project>/sessions/<session>/ layout."""
+    projects_dir = tmp_path / "projects"
+    slug = "-home-user-myproject"
     sid = "abc-123"
-    sdir = sessions_dir / sid
-    sdir.mkdir(parents=True)
-    (sdir / "metadata.json").write_text(
+
+    # Build nested structure: projects/<slug>/sessions/<sid>/metadata.json
+    session_dir = projects_dir / slug / "sessions" / sid
+    session_dir.mkdir(parents=True)
+    (session_dir / "metadata.json").write_text(
         json.dumps(
             {
                 "session_id": sid,
@@ -53,11 +56,68 @@ def test_rebuild_from_session_dirs(tmp_path):
             }
         )
     )
-    index = SessionIndex.rebuild(sessions_dir)
+
+    index = SessionIndex.rebuild(projects_dir)
     entry = index.get(sid)
     assert entry is not None
     assert entry.bundle == "test"
     assert entry.created_at == "2026-03-03T10:00:00Z"
+    assert entry.project_id == slug
+
+
+def test_rebuild_multiple_projects(tmp_path):
+    """Rebuild index scans sessions across multiple projects."""
+    projects_dir = tmp_path / "projects"
+    for i, (slug, sid) in enumerate(
+        [("-home-user-proj1", "sess-aaa"), ("-home-user-proj2", "sess-bbb")]
+    ):
+        sdir = projects_dir / slug / "sessions" / sid
+        sdir.mkdir(parents=True)
+        (sdir / "metadata.json").write_text(
+            json.dumps({"bundle": f"bundle-{i}", "created_at": "2026-03-03T10:00:00Z"})
+        )
+
+    index = SessionIndex.rebuild(projects_dir)
+    assert index.get("sess-aaa") is not None
+    assert index.get("sess-bbb") is not None
+    assert index.get("sess-aaa").project_id == "-home-user-proj1"
+    assert index.get("sess-bbb").project_id == "-home-user-proj2"
+
+
+def test_rebuild_skips_dirs_without_sessions_subdir(tmp_path):
+    """Rebuild ignores project dirs that have no sessions/ subdirectory."""
+    projects_dir = tmp_path / "projects"
+    # Project dir with no sessions/ sub-dir
+    orphan = projects_dir / "some-project"
+    orphan.mkdir(parents=True)
+    (orphan / "metadata.json").write_text("{}")  # stray file
+
+    index = SessionIndex.rebuild(projects_dir)
+    assert index.list_entries() == []
+
+
+def test_load_tolerates_missing_project_id(tmp_path):
+    """Loading an old index file that lacks project_id defaults it to empty string."""
+    path = tmp_path / "index.json"
+    # Write old-format entry without project_id
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "session_id": "old-sess",
+                    "status": "completed",
+                    "bundle": "distro",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "last_activity": "2026-01-01T00:00:00Z",
+                    "parent_session_id": None,
+                }
+            ]
+        )
+    )
+    index = SessionIndex.load(path)
+    entry = index.get("old-sess")
+    assert entry is not None
+    assert entry.project_id == ""
 
 
 def test_load_corrupted_falls_back_to_empty(tmp_path):
@@ -80,6 +140,22 @@ def test_update_entry(tmp_path):
     result = index.update("x", status="running")
     assert result is True
     assert index.get("x").status == "running"
+
+
+def test_update_project_id(tmp_path):
+    index = SessionIndex(tmp_path / "index.json")
+    index.add(
+        SessionIndexEntry(
+            session_id="x",
+            status="idle",
+            bundle="b",
+            created_at="2026-03-03T10:00:00Z",
+            last_activity="2026-03-03T10:00:00Z",
+        )
+    )
+    result = index.update("x", project_id="-home-user-proj")
+    assert result is True
+    assert index.get("x").project_id == "-home-user-proj"
 
 
 def test_update_unknown_session_returns_false(tmp_path):

--- a/tests/test_sessions_routes.py
+++ b/tests/test_sessions_routes.py
@@ -22,11 +22,11 @@ def client(tmp_path: Path) -> Generator[TestClient]:
     """Create a test client with an isolated session_manager."""
     app = create_app()
     with TestClient(app) as c:
-        # Override AFTER lifespan so the real sessions_dir is not scanned
+        # Override AFTER lifespan so the real projects_dir is not scanned
         event_bus = EventBus()
-        settings = DaemonSettings(sessions_dir=tmp_path / "sessions")
+        settings = DaemonSettings(projects_dir=tmp_path / "projects")
         c.app.state.session_manager = SessionManager(  # type: ignore[union-attr]
-            event_bus=event_bus, settings=settings, sessions_dir=tmp_path / "sessions"
+            event_bus=event_bus, settings=settings, projects_dir=tmp_path / "projects"
         )
         yield c
 
@@ -290,10 +290,10 @@ class TestSessionPatchNameEndpoint:
     ) -> None:
         """PATCH with name writes name to metadata.json in session dir."""
         manager = client.app.state.session_manager
-        sessions_dir = manager.sessions_dir
+        projects_dir = manager.projects_dir
         _register_handle(client, "sess-meta")
-        # Pre-create the session dir so write_metadata can find it
-        session_dir = sessions_dir / "sess-meta"
+        # Pre-create the nested session dir so resolve_session_dir can find it
+        session_dir = projects_dir / "-home-user-testproj" / "sessions" / "sess-meta"
         session_dir.mkdir(parents=True, exist_ok=True)
 
         resp = client.patch("/sessions/sess-meta", json={"name": "Renamed Session"})
@@ -343,17 +343,17 @@ class TestSessionPatchNameEndpoint:
     def test_patch_name_no_sessions_dir_still_emits_event(
         self, client: TestClient
     ) -> None:
-        """PATCH with name emits event even when sessions_dir is not configured."""
+        """PATCH with name emits event even when projects_dir is not configured."""
         import asyncio
         from amplifierd.state.session_manager import SessionManager
         from amplifierd.state.event_bus import EventBus
         from amplifierd.config import DaemonSettings
 
-        # Replace manager with one that has sessions_dir=None
+        # Replace manager with one that has projects_dir=None
         event_bus = EventBus()
         settings = DaemonSettings()
         no_persist_manager = SessionManager(
-            event_bus=event_bus, settings=settings, sessions_dir=None
+            event_bus=event_bus, settings=settings, projects_dir=None
         )
         client.app.state.session_manager = no_persist_manager
         client.app.state.event_bus = event_bus

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -12,35 +12,43 @@ from fastapi.testclient import TestClient
 from amplifierd.app import create_app
 from amplifierd.state.session_manager import SessionManager
 
+_TEST_SLUG = "-home-user-testproject"
+
 
 @pytest.fixture()
-def sessions_dir(tmp_path: Path) -> Path:
-    """Create a temporary sessions directory."""
-    d = tmp_path / "sessions"
+def projects_dir(tmp_path: Path) -> Path:
+    """Create a temporary projects directory."""
+    d = tmp_path / "projects"
     d.mkdir(parents=True)
     return d
 
 
-@pytest.fixture()
-def client(sessions_dir: Path) -> Generator[TestClient]:
-    """Test client with SessionManager configured with a sessions_dir.
+def _session_dir(projects_dir: Path, session_id: str) -> Path:
+    """Return the nested session directory path and ensure it exists."""
+    sdir = projects_dir / _TEST_SLUG / "sessions" / session_id
+    sdir.mkdir(parents=True, exist_ok=True)
+    return sdir
 
-    We patch sessions_dir onto the manager *after* lifespan runs (inside the
+
+@pytest.fixture()
+def client(projects_dir: Path) -> Generator[TestClient]:
+    """Test client with SessionManager configured with a projects_dir.
+
+    We patch _projects_dir onto the manager *after* lifespan runs (inside the
     context manager), so the lifespan's own SessionManager setup doesn't
-    overwrite our value.  Same pattern as test_session_creation.py.
+    overwrite our value.
     """
     app = create_app()
     with TestClient(app) as c:
         manager: SessionManager = c.app.state.session_manager  # type: ignore[union-attr]
-        manager._sessions_dir = sessions_dir  # noqa: SLF001
+        manager._projects_dir = projects_dir  # noqa: SLF001
         yield c
 
 
-def test_get_transcript_returns_messages(client: TestClient, sessions_dir: Path) -> None:
+def test_get_transcript_returns_messages(client: TestClient, projects_dir: Path) -> None:
     """GET /sessions/{id}/transcript reads messages from transcript.jsonl."""
     sid = "test-session-123"
-    sdir = sessions_dir / sid
-    sdir.mkdir(parents=True)
+    sdir = _session_dir(projects_dir, sid)
     transcript = sdir / "transcript.jsonl"
     transcript.write_text(
         json.dumps({"role": "user", "content": "hello"})
@@ -70,11 +78,10 @@ def test_get_transcript_missing_session(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
-def test_get_transcript_skips_malformed_lines(client: TestClient, sessions_dir: Path) -> None:
+def test_get_transcript_skips_malformed_lines(client: TestClient, projects_dir: Path) -> None:
     """GET /sessions/{id}/transcript skips lines that are not valid JSON."""
     sid = "session-malformed"
-    sdir = sessions_dir / sid
-    sdir.mkdir(parents=True)
+    sdir = _session_dir(projects_dir, sid)
     transcript = sdir / "transcript.jsonl"
     transcript.write_text(
         json.dumps({"role": "user", "content": "hello"})
@@ -91,11 +98,10 @@ def test_get_transcript_skips_malformed_lines(client: TestClient, sessions_dir: 
     assert len(data["messages"]) == 2
 
 
-def test_get_transcript_empty_file(client: TestClient, sessions_dir: Path) -> None:
+def test_get_transcript_empty_file(client: TestClient, projects_dir: Path) -> None:
     """GET /sessions/{id}/transcript returns empty messages for empty transcript."""
     sid = "session-empty"
-    sdir = sessions_dir / sid
-    sdir.mkdir(parents=True)
+    sdir = _session_dir(projects_dir, sid)
     (sdir / "transcript.jsonl").write_text("")
 
     resp = client.get(f"/sessions/{sid}/transcript")


### PR DESCRIPTION
## Summary

Switches amplifierd from flat `~/.amplifier/sessions/{id}/` to the CLI's project-nested `~/.amplifier/projects/{slug}/sessions/{id}/` layout. Sessions created by the daemon are now visible to the CLI and vice versa.

Fixes microsoft/amplifier-distro#177

### Why

The flat layout was a first-draft default (confirmed unintentional by @payneio). It caused:
- Plugin-chat sidebar only showed ~11 daemon sessions, not the user's 5,696 historical CLI/distro sessions
- Sessions created by amplifierd were invisible to `amplifier session list`
- Two separate session trees with no interop

### Changes

| File | What Changed |
|------|-------------|
| `config.py` | `sessions_dir` → `projects_dir` (default `~/.amplifier/projects/`). Added `cwd_to_slug()` utility |
| `session_index.py` | `SessionIndexEntry` gets `project_id` field. `rebuild()` walks two-level tree |
| `session_manager.py` | Constructor takes `projects_dir`. `create()` computes slug. Added `resolve_session_dir()` |
| `app.py` | Wired `projects_dir=settings.projects_dir` |
| `routes/sessions.py` | All flat paths replaced with `resolve_session_dir()` |
| `persistence.py` | No changes (already path-agnostic) |

### Tests
447/447 passing