### PR TITLE
fix: strip bundle: prefix from metadata on session resume

### DIFF
--- a/src/amplifierd/state/session_manager.py
+++ b/src/amplifierd/state/session_manager.py
@@ -354,6 +354,10 @@ class SessionManager:
         # 3. Load metadata to determine bundle and working_dir
         metadata = await asyncio.to_thread(load_metadata, session_dir)
         bundle_name = metadata.get("bundle", self._settings.default_bundle or "unknown")
+        # The CLI stores "bundle:mine" as a display convention; the registry
+        # expects the bare name "mine".  Strip the prefix before loading.
+        if bundle_name.startswith("bundle:"):
+            bundle_name = bundle_name[len("bundle:"):]
         working_dir = metadata.get("working_dir", str(Path.home()))
 
         # 4. Load bundle, inject providers, prepare, create session


### PR DESCRIPTION
## Summary

- `resume()` was passing the raw bundle name from session metadata to `BundleRegistry.load()`, but the CLI stores bundle names with a `bundle:` prefix (e.g. `"bundle:mine"`) as a display convention
- `BundleRegistry.load()` expects bare names (e.g. `"mine"`), causing `No handler for URI: bundle:mine` errors when resuming sessions
- Fix strips the `bundle:` prefix before loading, matching the pattern already used by `amplifier-app-cli`'s `extract_session_mode()`

## Test plan

- [ ] Resume a session that was created with a bundle (e.g. `bundle:mine`) — confirm it loads without `No handler for URI` error
- [ ] Resume a session with a bare bundle name (no prefix) — confirm it still works (guard is prefix-conditional)
- [ ] Create and resume a new session end-to-end to confirm no regression

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)