### PR TITLE
fix: merge_settings_providers() filters instead of injecting new providers

### DIFF
--- a/src/amplifierd/providers.py
+++ b/src/amplifierd/providers.py
@@ -72,31 +72,88 @@ def expand_env_vars(value: Any) -> Any:
     return value
 
 
+def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge *overlay* into *base*.
+
+    - Nested dicts are merged recursively (overlay wins on leaf conflicts).
+    - All other types: overlay value replaces base value.
+    """
+    result = base.copy()
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _merge_provider_item(
+    bundle_item: dict[str, Any], settings_item: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge a single settings provider entry on top of a bundle provider entry.
+
+    The ``config`` sub-dict is deep-merged so that bundle-specific keys
+    (e.g. ``debug``, ``default_model``) survive when settings only provides
+    runtime keys (e.g. ``api_key``, ``base_url``).  All other top-level
+    fields (``source``, ``module``, etc.) are taken from settings when present.
+    """
+    merged = bundle_item.copy()
+    for key, value in settings_item.items():
+        if key == "config" and key in merged:
+            if isinstance(merged["config"], dict) and isinstance(value, dict):
+                merged["config"] = _deep_merge(merged["config"], value)
+            else:
+                merged["config"] = value
+        else:
+            merged[key] = value
+    return merged
+
+
 def merge_settings_providers(
     existing: list[dict[str, Any]], settings_providers: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     """Merge settings providers into an existing provider list.
 
-    Settings override bundle providers by module ID.
-    Environment variables in settings values are expanded.
+    Semantics:
+
+    * **Bundle has providers** -- settings can only *update* providers the
+      bundle already declared.  New providers from settings are silently
+      dropped.  Matching providers are deep-merged (``config`` sub-dict is
+      merged recursively; other top-level fields are replaced).
+    * **Bundle has no providers** (provider-agnostic bundle) -- the full
+      settings provider list is used as-is so the session has something to
+      work with.
+
+    Environment variable references (``${VAR}``) are **not** expanded here.
+    Expansion happens later in ``inject_providers`` after the merge, so that
+    bundle-owned values survive when an env var is unset in the daemon.
 
     Args:
         existing: Current provider list (from bundle).
         settings_providers: Provider config list from load_provider_config().
 
     Returns:
-        Merged provider list with env vars expanded.
+        Merged provider list (env vars still unexpanded).
     """
     if not settings_providers:
         return list(existing)
-    expanded = expand_env_vars(settings_providers)
-    by_module: dict[str, dict[str, Any]] = {
-        p["module"]: p for p in existing if isinstance(p, dict) and "module" in p
+
+    # Provider-agnostic bundle: settings take over entirely.
+    if not existing:
+        return list(settings_providers)
+
+    # Bundle declares providers: settings may only update matches.
+    settings_by_module: dict[str, dict[str, Any]] = {
+        p["module"]: p for p in settings_providers if isinstance(p, dict) and "module" in p
     }
-    for p in expanded:
-        if isinstance(p, dict) and "module" in p:
-            by_module[p["module"]] = p
-    return list(by_module.values())
+    result: list[dict[str, Any]] = []
+    for p in existing:
+        module_id = p.get("module") if isinstance(p, dict) else None
+        if module_id and module_id in settings_by_module:
+            result.append(_merge_provider_item(p, settings_by_module[module_id]))
+        else:
+            result.append(p)
+    return result
 
 
 def inject_providers(bundle: Any, providers: list[dict[str, Any]]) -> None:
@@ -105,10 +162,16 @@ def inject_providers(bundle: Any, providers: list[dict[str, Any]]) -> None:
     Must be called BEFORE bundle.prepare() so that the activation step
     downloads and installs provider dependencies (e.g. the anthropic SDK).
 
+    The merge preserves the bundle's provider list as a whitelist -- settings
+    can configure existing providers but never inject new ones.  Environment
+    variables are expanded *after* the merge so that bundle-owned config
+    keys survive when a ${VAR} resolves to empty in the daemon.
+
     Args:
         bundle: An AmplifierBundle instance (has .providers list).
         providers: Provider config list from load_provider_config().
     """
     if not providers:
         return
-    bundle.providers = merge_settings_providers(bundle.providers, providers)
+    merged = merge_settings_providers(bundle.providers, providers)
+    bundle.providers = expand_env_vars(merged)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -131,14 +131,93 @@ def _make_bundle(
 
 
 @pytest.mark.unit
+class TestDeepMerge:
+    """Tests for _deep_merge()."""
+
+    def test_flat_overlay(self) -> None:
+        from amplifierd.providers import _deep_merge
+
+        base = {"a": 1, "b": 2}
+        overlay = {"b": 3, "c": 4}
+        assert _deep_merge(base, overlay) == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_merge(self) -> None:
+        from amplifierd.providers import _deep_merge
+
+        base = {"config": {"model": "gpt-4", "debug": True}}
+        overlay = {"config": {"api_key": "sk-123"}}
+        result = _deep_merge(base, overlay)
+        assert result == {"config": {"model": "gpt-4", "debug": True, "api_key": "sk-123"}}
+
+    def test_overlay_wins_on_conflict(self) -> None:
+        from amplifierd.providers import _deep_merge
+
+        base = {"config": {"model": "old"}}
+        overlay = {"config": {"model": "new"}}
+        assert _deep_merge(base, overlay) == {"config": {"model": "new"}}
+
+    def test_does_not_mutate_base(self) -> None:
+        from amplifierd.providers import _deep_merge
+
+        base = {"config": {"model": "gpt-4"}}
+        _deep_merge(base, {"config": {"api_key": "sk-123"}})
+        assert base == {"config": {"model": "gpt-4"}}
+
+
+@pytest.mark.unit
+class TestMergeProviderItem:
+    """Tests for _merge_provider_item()."""
+
+    def test_deep_merges_config(self) -> None:
+        from amplifierd.providers import _merge_provider_item
+
+        bundle = {"module": "provider-anthropic", "config": {"default_model": "claude-sonnet-4-6", "debug": True}}
+        settings = {"module": "provider-anthropic", "config": {"api_key": "${ANTHROPIC_API_KEY}"}}
+        result = _merge_provider_item(bundle, settings)
+        assert result["config"] == {
+            "default_model": "claude-sonnet-4-6",
+            "debug": True,
+            "api_key": "${ANTHROPIC_API_KEY}",
+        }
+
+    def test_settings_replaces_top_level_fields(self) -> None:
+        from amplifierd.providers import _merge_provider_item
+
+        bundle = {"module": "provider-anthropic", "source": "old-source"}
+        settings = {"module": "provider-anthropic", "source": "new-source"}
+        result = _merge_provider_item(bundle, settings)
+        assert result["source"] == "new-source"
+
+    def test_bundle_keys_preserved_when_settings_has_none(self) -> None:
+        from amplifierd.providers import _merge_provider_item
+
+        bundle = {"module": "provider-anthropic", "config": {"debug": True, "raw_debug": True}}
+        settings = {"module": "provider-anthropic"}
+        result = _merge_provider_item(bundle, settings)
+        assert result["config"] == {"debug": True, "raw_debug": True}
+
+
+@pytest.mark.unit
 class TestInjectProviders:
     """Tests for inject_providers()."""
 
-    def test_sets_providers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_empty_bundle_gets_settings_wholesale(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Provider-agnostic bundle gets all settings providers."""
         from amplifierd.providers import inject_providers
 
         monkeypatch.setenv("KEY", "val")
         bundle = _make_bundle()
+        providers = [{"module": "provider-test", "config": {"api_key": "${KEY}"}}]
+        inject_providers(bundle, providers)
+        assert len(bundle.providers) == 1
+        assert bundle.providers[0]["config"]["api_key"] == "val"
+
+    def test_updates_matching_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Settings update a provider the bundle already declares."""
+        from amplifierd.providers import inject_providers
+
+        monkeypatch.setenv("KEY", "val")
+        bundle = _make_bundle(providers=[{"module": "provider-test", "config": {"api_key": "old"}}])
         providers = [{"module": "provider-test", "config": {"api_key": "${KEY}"}}]
         inject_providers(bundle, providers)
         assert len(bundle.providers) == 1
@@ -151,7 +230,8 @@ class TestInjectProviders:
         inject_providers(bundle, [])
         assert bundle.providers == []
 
-    def test_merges_with_existing(self) -> None:
+    def test_does_not_inject_new_providers(self) -> None:
+        """Settings providers not in the bundle are silently dropped."""
         from amplifierd.providers import inject_providers
 
         bundle = _make_bundle(
@@ -164,10 +244,49 @@ class TestInjectProviders:
             {"module": "new-provider", "config": {"key": "added"}},
         ]
         inject_providers(bundle, providers)
-        assert len(bundle.providers) == 2
-        by_module = {p["module"]: p for p in bundle.providers}
-        assert by_module["existing-provider"]["config"]["key"] == "new"
-        assert by_module["new-provider"]["config"]["key"] == "added"
+        assert len(bundle.providers) == 1
+        assert bundle.providers[0]["module"] == "existing-provider"
+        assert bundle.providers[0]["config"]["key"] == "new"
+
+    def test_deep_merges_config_preserving_bundle_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bundle config keys survive when settings adds runtime keys."""
+        from amplifierd.providers import inject_providers
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        bundle = _make_bundle(providers=[{
+            "module": "provider-anthropic",
+            "config": {"default_model": "claude-sonnet-4-6", "debug": True},
+        }])
+        providers = [{
+            "module": "provider-anthropic",
+            "config": {"api_key": "${ANTHROPIC_API_KEY}"},
+        }]
+        inject_providers(bundle, providers)
+        assert len(bundle.providers) == 1
+        cfg = bundle.providers[0]["config"]
+        assert cfg["default_model"] == "claude-sonnet-4-6"
+        assert cfg["debug"] is True
+        assert cfg["api_key"] == "sk-test"
+
+    def test_env_expansion_after_merge_preserves_bundle_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When env var is unset, bundle config survives (not clobbered by empty expansion)."""
+        from amplifierd.providers import inject_providers
+
+        monkeypatch.delenv("UNSET_KEY", raising=False)
+        bundle = _make_bundle(providers=[{
+            "module": "provider-anthropic",
+            "config": {"default_model": "claude-sonnet-4-6", "debug": True},
+        }])
+        providers = [{
+            "module": "provider-anthropic",
+            "config": {"api_key": "${UNSET_KEY}"},
+        }]
+        inject_providers(bundle, providers)
+        cfg = bundle.providers[0]["config"]
+        # api_key expands to "" and gets stripped, but bundle keys survive
+        assert cfg["default_model"] == "claude-sonnet-4-6"
+        assert cfg["debug"] is True
+        assert "api_key" not in cfg
 
 
 @pytest.mark.unit
@@ -189,10 +308,57 @@ class TestMergeSettingsProviders:
         assert len(result) == 1
         assert result[0]["config"]["key"] == "new"
 
-    def test_adds_new_provider(self) -> None:
+    def test_does_not_add_new_provider(self) -> None:
+        """Settings providers not declared in the bundle are silently dropped."""
         from amplifierd.providers import merge_settings_providers
 
         existing = [{"module": "a", "config": {}}]
         settings = [{"module": "b", "config": {}}]
         result = merge_settings_providers(existing, settings)
+        assert len(result) == 1
+        assert result[0]["module"] == "a"
+
+    def test_empty_bundle_gets_settings(self) -> None:
+        """Provider-agnostic bundle (no providers) gets settings wholesale."""
+        from amplifierd.providers import merge_settings_providers
+
+        settings = [
+            {"module": "provider-anthropic", "config": {"api_key": "sk-123"}},
+            {"module": "provider-openai", "config": {"api_key": "sk-456"}},
+        ]
+        result = merge_settings_providers([], settings)
         assert len(result) == 2
+
+    def test_deep_merges_matching_config(self) -> None:
+        """Config sub-dict is deep-merged, not replaced."""
+        from amplifierd.providers import merge_settings_providers
+
+        existing = [{"module": "a", "config": {"model": "gpt-4", "debug": True}}]
+        settings = [{"module": "a", "config": {"api_key": "sk-123"}}]
+        result = merge_settings_providers(existing, settings)
+        assert result[0]["config"] == {"model": "gpt-4", "debug": True, "api_key": "sk-123"}
+
+    def test_no_env_expansion_in_merge(self) -> None:
+        """Env var references are preserved through merge (expanded later)."""
+        from amplifierd.providers import merge_settings_providers
+
+        existing = [{"module": "a", "config": {"debug": True}}]
+        settings = [{"module": "a", "config": {"api_key": "${MY_KEY}"}}]
+        result = merge_settings_providers(existing, settings)
+        assert result[0]["config"]["api_key"] == "${MY_KEY}"
+
+    def test_preserves_bundle_order(self) -> None:
+        """Result order matches bundle's provider order."""
+        from amplifierd.providers import merge_settings_providers
+
+        existing = [
+            {"module": "b", "config": {}},
+            {"module": "a", "config": {}},
+        ]
+        settings = [
+            {"module": "a", "config": {"key": "from-settings"}},
+            {"module": "b", "config": {"key": "from-settings"}},
+        ]
+        result = merge_settings_providers(existing, settings)
+        assert result[0]["module"] == "b"
+        assert result[1]["module"] == "a"


### PR DESCRIPTION
## Summary

- **Filter**: settings can only update providers the bundle already declared — they never inject new ones. A bundle declaring only `provider-anthropic` cannot end up with `provider-openai` etc. from `settings.yaml`.
- **Empty bundle passthrough**: provider-agnostic bundles (no providers declared) receive the full settings provider list wholesale, so they still have working providers at runtime.
- **Deep merge**: added `_deep_merge()` and `_merge_provider_item()` so the `config` sub-dict is recursively merged rather than replaced. Bundle-specific keys (`debug`, `default_model`) survive when settings adds runtime-only keys (`api_key`, `base_url`).
- **Expand-after-merge**: moved `expand_env_vars()` out of `merge_settings_providers()` and into `inject_providers()`, *after* the merge. Bundle-owned config keys now survive even when a `${VAR}` referenced by settings is unset in the daemon process.

### Before

```
bundle:   [provider-anthropic {default_model: claude-sonnet-4-6}]
settings: [provider-anthropic {api_key: ${ANTHROPIC_API_KEY}}, provider-openai, ...]
result:   [provider-anthropic {api_key: ""}, provider-openai, ...]
           ^ default_model clobbered, 5 providers injected
```

### After

```
bundle:   [provider-anthropic {default_model: claude-sonnet-4-6}]
settings: [provider-anthropic {api_key: ${ANTHROPIC_API_KEY}}, provider-openai, ...]
result:   [provider-anthropic {default_model: claude-sonnet-4-6, api_key: "sk-..."}]
           ^ bundle keys preserved, only declared provider retained
```

## Test plan

- [x] 33 tests pass (up from 20)
- [x] `TestDeepMerge` — flat overlay, nested merge, conflict resolution, no mutation
- [x] `TestMergeProviderItem` — config deep-merge, top-level field replacement, bundle key preservation
- [x] `TestMergeSettingsProviders` — filtering, empty bundle passthrough, bundle order preservation
- [x] `TestInjectProviders` — env expansion ordering, expand-after-merge contract

Fixes #9
Tracked in microsoft/amplifier-distro#187

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)