### PR TITLE
fix: invalidate install-state cache at daemon startup

### DIFF
--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -49,6 +49,23 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     app.state.event_bus = EventBus()
 
+    # Invalidate module install-state cache so that bundle.prepare() re-checks
+    # whether provider SDKs are actually installed in this venv.  The cache at
+    # ~/.amplifier/cache/install-state.json may be stale from another venv
+    # (e.g. the CLI's), causing ModuleActivator to skip installation even when
+    # packages like `anthropic` or `openai` are missing.  Invalidating is cheap
+    # — uv pip install -e is a fast no-op when packages are already present.
+    try:
+        from amplifier_foundation.modules.install_state import InstallStateManager
+        from amplifier_foundation.paths import get_amplifier_home
+
+        state = InstallStateManager(get_amplifier_home() / "cache")
+        state.invalidate()
+        state.save()
+        logger.debug("Invalidated module install-state cache")
+    except Exception:
+        logger.debug("Could not invalidate install-state cache", exc_info=True)
+
     # BundleRegistry — resilient: catches all exceptions, starts without registry
     try:
         from amplifier_foundation import BundleRegistry


### PR DESCRIPTION
## Summary

- At daemon startup (before `BundleRegistry` creation), invalidate foundation's `install-state.json` cache so `ModuleActivator` re-checks whether provider SDKs are actually installed in the current venv
- Fixes stale fingerprint problem: when `install-state.json` was written by a different venv (e.g. the CLI's), `ModuleActivator` skipped provider installation, causing `No module named 'anthropic'` errors and silent fallback to `github-copilot`
- Intentionally minimal: 3 lines of logic in a `try/except`; invalidation is cheap (`uv pip install -e` is a near-instant no-op when packages are present)

## Test plan

- [x] All 461 tests pass
- [x] Swarm review consensus: don't build a parallel installer, just invalidate the cache and let the existing `ModuleActivator` do its job

## Related issues

- Fixes microsoft/amplifier-distro#189 — tracking issue for this bug
- Related: microsoft/amplifier-distro#187 — parent provider injection issue
- Related: microsoft/amplifierd#9 — provider merge bug (already fixed in PR #8)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)