### PR TITLE
fix: replace amplifier-core git dependency with PyPI version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sse-starlette>=2.2.1",
     "click>=8.1.0",
     "pyyaml>=6.0",
-    "amplifier-core @ git+https://github.com/microsoft/amplifier-core",
+    "amplifier-core>=1.1.1",
     "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation",
 ]
 


### PR DESCRIPTION
Fixes #10

## Problem

`amplifier-core` was declared as a git source dependency, forcing a source build via maturin that requires a Rust toolchain. Any downstream consumer (e.g. `distro-service`) that pulls `amplifierd` from git fails at install time.

## Fix

Replace the git dependency with a PyPI version pin (`>=1.1.1`), so consumers get pre-built wheels without needing Rust.

```diff
- "amplifier-core @ git+https://github.com/microsoft/amplifier-core",
+ "amplifier-core>=1.1.1",
```

## Note on amplifier-foundation

The issue also flagged `amplifier-foundation` for the same pattern. However, `amplifier-foundation` only has a `0.0.0` placeholder on PyPI — it is not truly published yet, so the git dependency must remain for now. It should be converted to a PyPI pin once a real version is published.