### PR TITLE
feat: security layer — configurable CORS, API key auth, TLS, Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,14 @@ If you're working on amplifierd itself, use `uv run` from a local checkout:
 
 ```bash
 cd amplifierd
-uv sync
+uv sync --extra dev
 uv run amplifierd serve
+```
+
+To run the test suite:
+
+```bash
+uv run pytest
 ```
 
 ### Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "sse-starlette>=2.2.1",
     "click>=8.1.0",
     "pyyaml>=6.0",
-    "amplifier-core @ git+https://github.com/microsoft/amplifier-core",
+    "amplifier-core>=1.1.1",
     "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pythonVersion = "3.12"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+pythonpath = ["src"]
 markers = [
     "unit: unit tests",
     "integration: integration tests",

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -128,6 +128,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
 def create_app(settings: DaemonSettings | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
+    resolved_settings = settings or DaemonSettings()
+
     app = FastAPI(
         title="amplifierd",
         description="HTTP/SSE daemon for amplifier-core and amplifier-foundation",
@@ -138,17 +140,22 @@ def create_app(settings: DaemonSettings | None = None) -> FastAPI:
         lifespan=_lifespan,
     )
 
-    if settings is not None:
-        app.state.settings = settings
+    app.state.settings = resolved_settings
 
-    # CORS middleware
+    # CORS middleware — configurable via settings.allowed_origins
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=resolved_settings.allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # API key middleware — opt-in when api_key is configured
+    if resolved_settings.api_key:
+        from amplifierd.security.middleware import ApiKeyMiddleware
+
+        app.add_middleware(ApiKeyMiddleware, api_key=resolved_settings.api_key)
 
     register_error_handlers(app)
 

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -151,6 +151,15 @@ def create_app(settings: DaemonSettings | None = None) -> FastAPI:
         allow_headers=["*"],
     )
 
+    # Session auth middleware — opt-in when auth_enabled is True.
+    # Must be added before ApiKeyMiddleware so it sits *inside* it in the
+    # Starlette middleware stack (each add_middleware call wraps the current
+    # app, making the last-added middleware the outermost layer).
+    if resolved_settings.auth_enabled:
+        from amplifierd.security.middleware import SessionAuthMiddleware
+
+        app.add_middleware(SessionAuthMiddleware)
+
     # API key middleware — opt-in when api_key is configured
     if resolved_settings.api_key:
         from amplifierd.security.middleware import ApiKeyMiddleware

--- a/src/amplifierd/cli.py
+++ b/src/amplifierd/cli.py
@@ -41,6 +41,12 @@ def main() -> None:
     type=str,
     help="Default bundle name for sessions created without one.",
 )
+@click.option(
+    "--api-key",
+    default=None,
+    type=str,
+    help="Require API key for non-localhost requests.",
+)
 def serve(
     host: str | None,
     port: int | None,
@@ -48,6 +54,7 @@ def serve(
     log_level: str | None,
     bundle: tuple[str, ...],
     default_bundle: str | None,
+    api_key: str | None,
 ) -> None:
     """Start the amplifierd HTTP server."""
     import json
@@ -71,6 +78,9 @@ def serve(
 
     if default_bundle is not None:
         os.environ["AMPLIFIERD_DEFAULT_BUNDLE"] = default_bundle
+
+    if api_key is not None:
+        os.environ["AMPLIFIERD_API_KEY"] = api_key
 
     settings = DaemonSettings()
 

--- a/src/amplifierd/cli.py
+++ b/src/amplifierd/cli.py
@@ -47,6 +47,31 @@ def main() -> None:
     type=str,
     help="Require API key for non-localhost requests.",
 )
+@click.option(
+    "--tls",
+    "tls_mode",
+    default=None,
+    type=click.Choice(["auto", "off", "manual"], case_sensitive=False),
+    help="TLS mode: auto (Tailscale/self-signed), manual, off.",
+)
+@click.option(
+    "--ssl-certfile",
+    default=None,
+    type=click.Path(),
+    help="Path to SSL certificate (implies --tls manual).",
+)
+@click.option(
+    "--ssl-keyfile",
+    default=None,
+    type=click.Path(),
+    help="Path to SSL private key.",
+)
+@click.option(
+    "--no-auth",
+    is_flag=True,
+    default=False,
+    help="Disable authentication even when TLS is active.",
+)
 def serve(
     host: str | None,
     port: int | None,
@@ -55,6 +80,10 @@ def serve(
     bundle: tuple[str, ...],
     default_bundle: str | None,
     api_key: str | None,
+    tls_mode: str | None,
+    ssl_certfile: str | None,
+    ssl_keyfile: str | None,
+    no_auth: bool,
 ) -> None:
     """Start the amplifierd HTTP server."""
     import json
@@ -82,6 +111,17 @@ def serve(
     if api_key is not None:
         os.environ["AMPLIFIERD_API_KEY"] = api_key
 
+    if tls_mode is not None:
+        os.environ["AMPLIFIERD_TLS_MODE"] = tls_mode
+    if ssl_certfile is not None:
+        os.environ["AMPLIFIERD_TLS_CERTFILE"] = ssl_certfile
+        if tls_mode is None:
+            os.environ["AMPLIFIERD_TLS_MODE"] = "manual"
+    if ssl_keyfile is not None:
+        os.environ["AMPLIFIERD_TLS_KEYFILE"] = ssl_keyfile
+    if no_auth:
+        os.environ["AMPLIFIERD_AUTH_ENABLED"] = "false"
+
     settings = DaemonSettings()
 
     effective_host = host if host is not None else settings.host
@@ -108,6 +148,11 @@ def serve(
     # Store the daemon session path in env so the app lifespan can pick it up
     os.environ["AMPLIFIERD_DAEMON_SESSION_PATH"] = str(session_path)
 
+    # 3. Resolve TLS configuration (Tailscale probe + cert resolution)
+    from amplifierd.security.tls import resolve_tls
+
+    ssl_kwargs = resolve_tls(settings, effective_port)
+
     click.echo(
         f"amplifierd starting – host={effective_host} port={effective_port} "
         f"log-level={effective_log_level}"
@@ -120,6 +165,7 @@ def serve(
         reload=reload,
         log_level=effective_log_level,
         factory=True,
+        **ssl_kwargs,
     )
 
 

--- a/src/amplifierd/config.py
+++ b/src/amplifierd/config.py
@@ -74,6 +74,10 @@ class DaemonSettings(BaseSettings):
     default_bundle: str | None = "distro"
     daemon_session_path: Path | None = None
 
+    # Security — opt-in, defaults preserve current localhost-only behavior
+    allowed_origins: list[str] = Field(default_factory=lambda: ["*"])
+    api_key: str | None = None
+
     # Class-level storage for settings_dir (used by settings_customise_sources).
     # Not thread-safe: concurrent construction would race on this value.
     # Acceptable — this runs once at daemon startup, not on a hot path.

--- a/src/amplifierd/config.py
+++ b/src/amplifierd/config.py
@@ -77,6 +77,10 @@ class DaemonSettings(BaseSettings):
     # Security — opt-in, defaults preserve current localhost-only behavior
     allowed_origins: list[str] = Field(default_factory=lambda: ["*"])
     api_key: str | None = None
+    tls_mode: str = "off"  # off | auto | manual
+    tls_certfile: str | None = None
+    tls_keyfile: str | None = None
+    auth_enabled: bool = False
 
     # Class-level storage for settings_dir (used by settings_customise_sources).
     # Not thread-safe: concurrent construction would race on this value.

--- a/src/amplifierd/security/__init__.py
+++ b/src/amplifierd/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security layer for amplifierd — TLS, authentication, and CORS."""

--- a/src/amplifierd/security/certs.py
+++ b/src/amplifierd/security/certs.py
@@ -1,0 +1,126 @@
+"""Self-signed TLS certificate generation for amplifierd.
+
+Primary path uses the ``openssl`` CLI; falls back to the ``cryptography``
+Python library when ``openssl`` is not available on the system PATH.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CERT_NAME = "self-signed.pem"
+_KEY_NAME = "self-signed-key.pem"
+
+
+def generate_self_signed_cert(cert_dir: Path) -> tuple[Path, Path]:
+    """Generate a self-signed TLS certificate and key in *cert_dir*.
+
+    Returns ``(cert_path, key_path)``.  If both files already exist they are
+    reused without regeneration.  Creates *cert_dir* if it does not exist.
+
+    Raises :class:`RuntimeError` if neither ``openssl`` CLI nor the
+    ``cryptography`` Python package is available.
+    """
+    cert_dir.mkdir(parents=True, exist_ok=True)
+
+    cert_path = cert_dir / _CERT_NAME
+    key_path = cert_dir / _KEY_NAME
+
+    # Reuse existing cert if both files are present.
+    if cert_path.exists() and key_path.exists():
+        logger.debug("Reusing existing self-signed cert in %s", cert_dir)
+        return cert_path, key_path
+
+    # Try openssl CLI first.
+    if _generate_via_openssl(cert_path, key_path):
+        key_path.chmod(0o600)
+        return cert_path, key_path
+
+    # Fallback to cryptography library.
+    if _generate_via_cryptography(cert_path, key_path):
+        key_path.chmod(0o600)
+        return cert_path, key_path
+
+    msg = (
+        "Cannot generate self-signed certificate: "
+        "neither openssl CLI nor the cryptography Python package is available"
+    )
+    raise RuntimeError(msg)
+
+
+def _generate_via_openssl(cert_path: Path, key_path: Path) -> bool:
+    """Generate cert/key using the ``openssl`` CLI.  Returns True on success."""
+    try:
+        subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                str(key_path),
+                "-out",
+                str(cert_path),
+                "-days",
+                "3650",
+                "-nodes",
+                "-subj",
+                "/CN=localhost",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        )
+    except FileNotFoundError:
+        logger.debug("openssl CLI not found, trying fallback")
+        return False
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        logger.warning("openssl failed: %s", exc)
+        return False
+    else:
+        logger.debug("Generated self-signed cert via openssl CLI")
+        return True
+
+
+def _generate_via_cryptography(cert_path: Path, key_path: Path) -> bool:
+    """Generate cert/key via ``cryptography`` library.  Returns True on success."""
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+    except ImportError:
+        logger.debug("cryptography library not available")
+        return False
+
+    import datetime
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.datetime.now(datetime.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=3650))
+        .sign(key, hashes.SHA256())
+    )
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    logger.debug("Generated self-signed cert via cryptography library")
+    return True

--- a/src/amplifierd/security/middleware.py
+++ b/src/amplifierd/security/middleware.py
@@ -1,4 +1,4 @@
-"""API key authentication middleware for amplifierd."""
+"""API key and session authentication middleware for amplifierd."""
 
 from __future__ import annotations
 
@@ -7,13 +7,19 @@ import logging
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, RedirectResponse, Response
 
 logger = logging.getLogger(__name__)
 
 _LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 _PUBLIC_PATHS = {"/health", "/info", "/docs", "/redoc", "/openapi.json"}
+
+# Paths that must always be reachable even without a valid session.
+# Includes the auth endpoints themselves and static assets for the login page.
+_AUTH_PATHS = {"/login", "/logout", "/auth/me"}
+
+_SESSION_COOKIE = "amplifier_session"
 
 
 def is_localhost(host: str | None) -> bool:
@@ -60,4 +66,59 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
         return JSONResponse(
             status_code=401,
             content={"detail": "Invalid or missing API key"},
+        )
+
+
+class SessionAuthMiddleware(BaseHTTPMiddleware):
+    """Enforce session cookie authentication for all non-public routes.
+
+    The auth plugin registers a ``verify_session`` callable on
+    ``app.state.auth_verify_session`` at startup.  This middleware reads that
+    callable on every request so the secret is resolved after the plugin has
+    fully initialised.
+
+    Bypass order:
+    1. Auth paths (/login, /logout, /auth/me) -> always pass
+    2. Public paths (/health, /info, /docs, /redoc, /openapi.json) -> always pass
+    3. Valid ``amplifier_session`` cookie -> pass
+    4. HTML-accepting clients -> redirect to /login
+    5. Otherwise -> 401 JSON
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[no-untyped-def]
+        path = request.url.path
+
+        # Auth and public paths are always reachable
+        if path in _AUTH_PATHS or path in _PUBLIC_PATHS:
+            return await call_next(request)
+
+        # Retrieve the verify callable stored by the auth plugin at startup.
+        # If it isn't present the plugin didn't load — fail open so a broken
+        # plugin doesn't lock everyone out.
+        verify = getattr(request.app.state, "auth_verify_session", None)
+        if verify is None:
+            logger.warning(
+                "SessionAuthMiddleware active but auth_verify_session not set "
+                "(auth plugin may not have loaded); passing request through"
+            )
+            return await call_next(request)
+
+        # Check the session cookie
+        session_token = request.cookies.get(_SESSION_COOKIE)
+        if session_token is not None and verify(session_token) is not None:
+            return await call_next(request)
+
+        logger.debug(
+            "Unauthenticated request to %s from %s",
+            path,
+            request.client.host if request.client else "unknown",
+        )
+
+        # Return a redirect for browser requests, plain 401 for API clients
+        if "text/html" in request.headers.get("accept", ""):
+            return RedirectResponse(url="/login", status_code=302)
+
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Authentication required"},
         )

--- a/src/amplifierd/security/middleware.py
+++ b/src/amplifierd/security/middleware.py
@@ -115,9 +115,12 @@ class SessionAuthMiddleware(BaseHTTPMiddleware):
             request.client.host if request.client else "unknown",
         )
 
-        # Return a redirect for browser requests, plain 401 for API clients
+        # Return a redirect for browser requests, plain 401 for API clients.
+        # Preserve the original URL so the login page can redirect back.
         if "text/html" in request.headers.get("accept", ""):
-            return RedirectResponse(url="/login", status_code=302)
+            from urllib.parse import quote
+
+            return RedirectResponse(url=f"/login?next={quote(path, safe='/')}", status_code=302)
 
         return JSONResponse(
             status_code=401,

--- a/src/amplifierd/security/middleware.py
+++ b/src/amplifierd/security/middleware.py
@@ -1,0 +1,63 @@
+"""API key authentication middleware for amplifierd."""
+
+from __future__ import annotations
+
+import hmac
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+_LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+_PUBLIC_PATHS = {"/health", "/info", "/docs", "/redoc", "/openapi.json"}
+
+
+def is_localhost(host: str | None) -> bool:
+    """Check if the request originates from localhost."""
+    return host in _LOCALHOST_HOSTS or host is None
+
+
+class ApiKeyMiddleware(BaseHTTPMiddleware):
+    """Require API key for non-localhost requests.
+
+    Bypass order:
+    1. Localhost requests -> always pass
+    2. Public paths (/health, /info, /docs, /redoc, /openapi.json) -> always pass
+    3. Valid Authorization: Bearer <api_key> -> pass
+    4. Otherwise -> 401
+    """
+
+    def __init__(self, app, api_key: str) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(app)
+        self.api_key = api_key
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[no-untyped-def]
+        # Localhost always bypasses
+        client_host = request.client.host if request.client else None
+        if is_localhost(client_host):
+            return await call_next(request)
+
+        # Public paths bypass
+        if request.url.path in _PUBLIC_PATHS:
+            return await call_next(request)
+
+        # Check Bearer token
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:]
+            if hmac.compare_digest(token, self.api_key):
+                return await call_next(request)
+
+        logger.warning(
+            "Rejected request from %s to %s: missing or invalid API key",
+            client_host,
+            request.url.path,
+        )
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Invalid or missing API key"},
+        )

--- a/src/amplifierd/security/middleware.py
+++ b/src/amplifierd/security/middleware.py
@@ -16,8 +16,8 @@ _LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1"}
 _PUBLIC_PATHS = {"/health", "/info", "/docs", "/redoc", "/openapi.json"}
 
 # Paths that must always be reachable even without a valid session.
-# Includes the auth endpoints themselves and static assets for the login page.
-_AUTH_PATHS = {"/login", "/logout", "/auth/me"}
+# Includes the auth endpoints themselves, static assets, and favicon.
+_AUTH_PATHS = {"/login", "/logout", "/auth/me", "/favicon.svg"}
 
 _SESSION_COOKIE = "amplifier_session"
 
@@ -78,18 +78,19 @@ class SessionAuthMiddleware(BaseHTTPMiddleware):
     fully initialised.
 
     Bypass order:
-    1. Auth paths (/login, /logout, /auth/me) -> always pass
+    1. Auth paths (/login, /logout, /auth/me, /favicon.svg) -> always pass
     2. Public paths (/health, /info, /docs, /redoc, /openapi.json) -> always pass
-    3. Valid ``amplifier_session`` cookie -> pass
-    4. HTML-accepting clients -> redirect to /login
-    5. Otherwise -> 401 JSON
+    3. Static assets (/static/*) -> always pass
+    4. Valid ``amplifier_session`` cookie -> pass
+    5. HTML-accepting clients -> redirect to /login
+    6. Otherwise -> 401 JSON
     """
 
     async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[no-untyped-def]
         path = request.url.path
 
-        # Auth and public paths are always reachable
-        if path in _AUTH_PATHS or path in _PUBLIC_PATHS:
+        # Auth, public, and static asset paths are always reachable
+        if path in _AUTH_PATHS or path in _PUBLIC_PATHS or path.startswith("/static/"):
             return await call_next(request)
 
         # Retrieve the verify callable stored by the auth plugin at startup.

--- a/src/amplifierd/security/origins.py
+++ b/src/amplifierd/security/origins.py
@@ -1,0 +1,52 @@
+"""Dynamic CORS origin allow-list for amplifierd.
+
+Builds a deduplicated allow-list from known-good sources (localhost,
+Tailscale DNS, system hostname, explicit extras).  No wildcards —
+enumerate known-good only.
+"""
+
+from __future__ import annotations
+
+import socket
+
+from amplifierd.security.tailscale import get_dns_name
+
+
+def build_allowed_origins(extra: list[str] | None = None) -> list[str]:
+    """Build a deduplicated origin allow-list.
+
+    Always includes localhost and 127.0.0.1.  Adds the Tailscale DNS
+    name (if available), the system hostname, and any explicit *extra*
+    entries.  Returns a deduplicated list preserving insertion order.
+    """
+    origins: list[str] = ["localhost", "127.0.0.1"]
+
+    # Tailscale DNS name (may be None)
+    ts_name = get_dns_name()
+    if ts_name:
+        origins.append(ts_name)
+
+    # System hostname
+    hostname = socket.gethostname()
+    if hostname:
+        origins.append(hostname)
+
+    # Explicit extras
+    if extra:
+        origins.extend(extra)
+
+    # Deduplicate preserving insertion order
+    return list(dict.fromkeys(origins))
+
+
+def is_origin_allowed(origin: str | None, allowed: set[str]) -> bool:
+    """Check if an Origin header value matches the allow-list.
+
+    - ``None`` origin (no header) is always allowed.
+    - Otherwise, returns ``True`` if any entry in *allowed* is a
+      substring of *origin*.
+    """
+    if origin is None:
+        return True
+    # Substring match is intentional — entries are host fragments, not full URLs.
+    return any(entry in origin for entry in allowed)

--- a/src/amplifierd/security/tailscale.py
+++ b/src/amplifierd/security/tailscale.py
@@ -1,0 +1,166 @@
+"""Tailscale remote-access integration for amplifierd.
+
+Auto-detects Tailscale and sets up HTTPS reverse proxy via ``tailscale serve``.
+No configuration needed -- if Tailscale is connected, it just works.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def get_dns_name() -> str | None:
+    """Get the MagicDNS name if Tailscale is connected.
+
+    Returns e.g. ``"win-dlpodl2cijb.tail79ce67.ts.net"`` or ``None``.
+    """
+    try:
+        result = subprocess.run(
+            ["tailscale", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+        if data.get("BackendState") != "Running":
+            return None
+
+        dns = data.get("Self", {}).get("DNSName", "").rstrip(".")
+        return dns or None
+
+    except (
+        FileNotFoundError,
+        PermissionError,
+        subprocess.TimeoutExpired,
+        json.JSONDecodeError,
+    ):
+        return None
+
+
+def start_serve(port: int) -> str | None:
+    """Start ``tailscale serve`` to proxy HTTPS -> localhost:port.
+
+    Returns the HTTPS URL on success, or ``None`` on any failure.
+    Failures are logged but never raise -- the server starts regardless.
+    """
+    dns_name = get_dns_name()
+    if dns_name is None:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["tailscale", "serve", "--bg", str(port)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            if "not enabled" in stderr.lower() or "enable" in stderr.lower():
+                logger.warning(
+                    "Tailscale Serve not enabled on tailnet. "
+                    "Enable HTTPS in Tailscale admin: "
+                    "https://login.tailscale.com/admin/dns"
+                )
+            else:
+                logger.warning("tailscale serve failed: %s", stderr)
+            return None
+
+        url = f"https://{dns_name}"
+        logger.info("Tailscale HTTPS active: %s -> localhost:%d", url, port)
+        return url
+
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        logger.debug("tailscale serve unavailable: %s", exc)
+        return None
+
+
+def provision_cert(cert_dir: Path) -> tuple[Path, Path] | None:
+    """Provision a TLS certificate via ``tailscale cert``.
+
+    Returns ``(cert_path, key_path)`` on success, or ``None`` on any failure.
+    Creates *cert_dir* if it does not exist.  Failures are logged but never
+    raise.
+    """
+    dns_name = get_dns_name()
+    if dns_name is None:
+        return None
+
+    cert_dir.mkdir(parents=True, exist_ok=True)
+
+    cert_file = cert_dir / f"{dns_name}.crt"
+    key_file = cert_dir / f"{dns_name}.key"
+
+    try:
+        result = subprocess.run(
+            [
+                "tailscale",
+                "cert",
+                "--cert-file",
+                str(cert_file),
+                "--key-file",
+                str(key_file),
+                dns_name,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            logger.warning("tailscale cert failed: %s", stderr)
+            import click
+
+            click.echo("")
+            click.echo(
+                click.style(
+                    "  \u26a0 Tailscale certificate provisioning failed",
+                    fg="yellow",
+                    bold=True,
+                )
+            )
+            if "access denied" in stderr.lower():
+                click.echo("  Your user doesn't have permission to request certs.")
+                click.echo("  Fix: Run once then restart the server:")
+                click.echo(
+                    click.style("    sudo tailscale set --operator=$USER", bold=True)
+                )
+            elif "does not support" in stderr.lower():
+                click.echo(
+                    "  HTTPS certificates are not enabled for your Tailscale account."
+                )
+                click.echo("  Fix: Enable HTTPS in your Tailscale admin console:")
+                click.echo(
+                    click.style("    https://login.tailscale.com/admin/dns", bold=True)
+                )
+                click.echo("  Check 'Enable HTTPS' then restart the server.")
+            else:
+                click.echo(f"  {stderr}")
+            click.echo("")
+            return None
+
+        return (cert_file, key_file)
+
+    except subprocess.TimeoutExpired:
+        logger.debug("tailscale cert timed out")
+        return None
+
+
+def stop_serve() -> None:
+    """Tear down ``tailscale serve``. Idempotent -- safe if not serving."""
+    with contextlib.suppress(FileNotFoundError, subprocess.TimeoutExpired):
+        subprocess.run(
+            ["tailscale", "serve", "off"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )

--- a/src/amplifierd/security/tls.py
+++ b/src/amplifierd/security/tls.py
@@ -1,0 +1,84 @@
+"""TLS orchestration for amplifierd.
+
+Resolves TLS configuration from settings, enforcing the Tailscale/native-TLS
+mutual exclusion invariant:
+
+- If ``tailscale serve`` is active → no native TLS (Tailscale proxies HTTPS)
+- If ``tailscale serve`` is not active → resolve certs per ``tls_mode``
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+from typing import TYPE_CHECKING, Any
+
+import click
+
+from amplifierd.security import certs, tailscale
+
+if TYPE_CHECKING:
+    from amplifierd.config import DaemonSettings
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_tls(settings: DaemonSettings, port: int) -> dict[str, Any]:
+    """Resolve TLS configuration.  Returns ``ssl_kwargs`` dict for ``uvicorn.run()``.
+
+    Enforces the mutual exclusion invariant:
+
+    - If Tailscale serve is active → return ``{}`` (no native TLS needed)
+    - If Tailscale serve is not active → resolve certs per ``tls_mode``
+
+    Modes:
+
+    ``off``
+        Returns ``{}``.
+    ``auto``
+        Probes Tailscale serve first.  If unavailable, tries
+        ``tailscale cert`` then falls back to self-signed.
+    ``manual``
+        Validates the provided ``tls_certfile`` / ``tls_keyfile`` paths.
+    """
+    if settings.tls_mode == "off":
+        return {}
+
+    # Phase 1: Tailscale serve probe (must be first — determines TLS strategy)
+    ts_url = tailscale.start_serve(port)
+    if ts_url:
+        atexit.register(tailscale.stop_serve)
+        click.echo(click.style(f"  \u2713 HTTPS via Tailscale: {ts_url}", fg="green"))
+        return {}  # Tailscale handles HTTPS — no native TLS
+
+    # Phase 2: Cert resolution (only reached if no Tailscale serve)
+    if settings.tls_mode == "manual":
+        if (
+            not settings.tls_certfile
+            or not settings.tls_keyfile
+            or not _path_exists(settings.tls_certfile)
+            or not _path_exists(settings.tls_keyfile)
+        ):
+            raise click.UsageError(
+                "--tls manual requires valid --ssl-certfile and --ssl-keyfile paths"
+            )
+        return {"ssl_certfile": settings.tls_certfile, "ssl_keyfile": settings.tls_keyfile}
+
+    # mode == "auto" — try Tailscale cert, then self-signed
+    cert_dir = settings.home_dir / "certs"
+    ts_cert = tailscale.provision_cert(cert_dir)
+    if ts_cert is not None:
+        click.echo(click.style("  \u2713 Using Tailscale certificate for TLS", fg="green"))
+        return {"ssl_certfile": str(ts_cert[0]), "ssl_keyfile": str(ts_cert[1])}
+
+    # Fall back to self-signed
+    click.echo(click.style("  \u26a0 Using self-signed certificate", fg="yellow", bold=True))
+    cert_path, key_path = certs.generate_self_signed_cert(cert_dir)
+    return {"ssl_certfile": str(cert_path), "ssl_keyfile": str(key_path)}
+
+
+def _path_exists(path: str) -> bool:
+    """Check if a path exists on the filesystem."""
+    from pathlib import Path
+
+    return Path(path).exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,7 +63,6 @@ class TestServeDefaults:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -93,7 +92,6 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-
         ):
             result = runner.invoke(
                 main, ["serve", "--host", "0.0.0.0", "--port", "9000", "--log-level", "debug"]
@@ -121,7 +119,6 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-
         ):
             result = runner.invoke(main, ["serve", "--reload"])
 
@@ -153,7 +150,6 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -176,7 +172,6 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -198,10 +193,43 @@ class TestServeLogging:
             patch("logging.basicConfig") as mock_basic_config,
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
-
         ):
             result = runner.invoke(main, ["serve", "--log-level", "debug"])
 
         assert result.exit_code == 0
         call_kwargs = mock_basic_config.call_args[1]
         assert call_kwargs["level"] == logging.DEBUG
+
+
+class TestServeApiKeyFlag:
+    """serve --api-key flag sets AMPLIFIERD_API_KEY env var."""
+
+    def test_serve_help_contains_api_key_flag(self) -> None:
+        runner = CliRunner()
+        result: Result = runner.invoke(main, ["serve", "--help"])
+        assert "--api-key" in result.output
+
+    def test_api_key_flag_sets_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_settings = MagicMock()
+        mock_settings.host = "127.0.0.1"
+        mock_settings.port = 8410
+        mock_settings.log_level = "info"
+
+        monkeypatch.delenv("AMPLIFIERD_API_KEY", raising=False)
+
+        runner = CliRunner()
+        with (
+            patch("uvicorn.run"),
+            patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
+            patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
+            patch("amplifierd.daemon_session.setup_session_log"),
+        ):
+            result = runner.invoke(
+                main, ["serve", "--api-key", "my-secret"], env={"AMPLIFIERD_API_KEY": ""}
+            )
+
+        assert result.exit_code == 0
+        # The serve function sets os.environ directly; verify it was set during invocation
+        # We can't check os.environ after invoke since CliRunner may restore env.
+        # Instead, verify the flag was accepted without error.
+        assert result.output  # command ran successfully

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,23 @@ def _restore_root_handlers():
     logging.getLogger().handlers = original_handlers
 
 
+@pytest.fixture(autouse=True)
+def _clean_security_env_vars():
+    """Remove security env vars set by CLI serve function to prevent cross-test leakage."""
+    import os
+
+    _SECURITY_VARS = [
+        "AMPLIFIERD_API_KEY",
+        "AMPLIFIERD_TLS_MODE",
+        "AMPLIFIERD_TLS_CERTFILE",
+        "AMPLIFIERD_TLS_KEYFILE",
+        "AMPLIFIERD_AUTH_ENABLED",
+    ]
+    yield
+    for var in _SECURITY_VARS:
+        os.environ.pop(var, None)
+
+
 class TestServeHelp:
     """CliRunner invoke of main with ['serve', '--help'] should exit 0
     and output should contain '--port', '--host', '--reload'."""
@@ -63,6 +80,7 @@ class TestServeDefaults:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("amplifierd.security.tls.resolve_tls", return_value={}),
         ):
             result = runner.invoke(main, ["serve"])
 
@@ -92,6 +110,7 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("amplifierd.security.tls.resolve_tls", return_value={}),
         ):
             result = runner.invoke(
                 main, ["serve", "--host", "0.0.0.0", "--port", "9000", "--log-level", "debug"]
@@ -119,6 +138,7 @@ class TestServeCLIOverrides:
             patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
             patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
             patch("amplifierd.daemon_session.setup_session_log"),
+            patch("amplifierd.security.tls.resolve_tls", return_value={}),
         ):
             result = runner.invoke(main, ["serve", "--reload"])
 
@@ -199,6 +219,49 @@ class TestServeLogging:
         assert result.exit_code == 0
         call_kwargs = mock_basic_config.call_args[1]
         assert call_kwargs["level"] == logging.DEBUG
+
+
+class TestServeTlsFlags:
+    """serve --tls and --ssl-* flags appear in help and set env vars."""
+
+    def test_serve_help_contains_tls_flag(self) -> None:
+        runner = CliRunner()
+        result: Result = runner.invoke(main, ["serve", "--help"])
+        assert "--tls" in result.output
+
+    def test_serve_help_contains_ssl_certfile_flag(self) -> None:
+        runner = CliRunner()
+        result: Result = runner.invoke(main, ["serve", "--help"])
+        assert "--ssl-certfile" in result.output
+
+    def test_serve_help_contains_ssl_keyfile_flag(self) -> None:
+        runner = CliRunner()
+        result: Result = runner.invoke(main, ["serve", "--help"])
+        assert "--ssl-keyfile" in result.output
+
+    def test_serve_help_contains_no_auth_flag(self) -> None:
+        runner = CliRunner()
+        result: Result = runner.invoke(main, ["serve", "--help"])
+        assert "--no-auth" in result.output
+
+    def test_tls_flags_accepted_without_error(self) -> None:
+        """serve accepts --tls, --ssl-certfile, --ssl-keyfile, --no-auth without error."""
+        mock_settings = MagicMock()
+        mock_settings.host = "127.0.0.1"
+        mock_settings.port = 8410
+        mock_settings.log_level = "info"
+
+        runner = CliRunner()
+        with (
+            patch("uvicorn.run"),
+            patch("amplifierd.config.DaemonSettings", return_value=mock_settings),
+            patch("amplifierd.daemon_session.create_session_dir", return_value=MagicMock()),
+            patch("amplifierd.daemon_session.setup_session_log"),
+            patch("amplifierd.security.tls.resolve_tls", return_value={}),
+        ):
+            result = runner.invoke(main, ["serve", "--tls", "auto", "--no-auth"])
+
+        assert result.exit_code == 0
 
 
 class TestServeApiKeyFlag:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,9 +106,7 @@ class TestDaemonSettings:
         from amplifierd.config import DaemonSettings
 
         settings_file = tmp_path / "settings.json"
-        settings_file.write_text(
-            json.dumps({"bundles": {"custom": "file:///tmp/mybundle"}})
-        )
+        settings_file.write_text(json.dumps({"bundles": {"custom": "file:///tmp/mybundle"}}))
         settings = DaemonSettings(_settings_dir=tmp_path)
         assert settings.bundles == {"custom": "file:///tmp/mybundle"}
 
@@ -130,3 +128,54 @@ class TestDaemonSettings:
         monkeypatch.setenv("AMPLIFIERD_DEFAULT_BUNDLE", "foundation")
         settings = DaemonSettings(_settings_dir=tmp_path)
         assert settings.default_bundle == "foundation"
+
+    def test_allowed_origins_defaults_to_wildcard(self, tmp_path: Path):
+        """allowed_origins defaults to ['*'] (permit all)."""
+        from amplifierd.config import DaemonSettings
+
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.allowed_origins == ["*"]
+
+    def test_api_key_defaults_to_none(self, tmp_path: Path):
+        """api_key defaults to None (no auth)."""
+        from amplifierd.config import DaemonSettings
+
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.api_key is None
+
+    def test_allowed_origins_from_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """AMPLIFIERD_ALLOWED_ORIGINS env var overrides default."""
+        from amplifierd.config import DaemonSettings
+
+        monkeypatch.setenv(
+            "AMPLIFIERD_ALLOWED_ORIGINS",
+            '["http://localhost:3000","https://my.host"]',
+        )
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.allowed_origins == ["http://localhost:3000", "https://my.host"]
+
+    def test_api_key_from_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """AMPLIFIERD_API_KEY env var sets the api_key."""
+        from amplifierd.config import DaemonSettings
+
+        monkeypatch.setenv("AMPLIFIERD_API_KEY", "my-secret-key")
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.api_key == "my-secret-key"
+
+    def test_allowed_origins_from_json(self, tmp_path: Path):
+        """allowed_origins can be set from settings.json."""
+        from amplifierd.config import DaemonSettings
+
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({"allowed_origins": ["https://example.com"]}))
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.allowed_origins == ["https://example.com"]
+
+    def test_api_key_from_json(self, tmp_path: Path):
+        """api_key can be set from settings.json."""
+        from amplifierd.config import DaemonSettings
+
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({"api_key": "json-secret"}))
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.api_key == "json-secret"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,3 +179,40 @@ class TestDaemonSettings:
         settings_file.write_text(json.dumps({"api_key": "json-secret"}))
         settings = DaemonSettings(_settings_dir=tmp_path)
         assert settings.api_key == "json-secret"
+
+    def test_tls_mode_defaults_to_off(self, tmp_path: Path):
+        """tls_mode defaults to 'off'."""
+        from amplifierd.config import DaemonSettings
+
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.tls_mode == "off"
+
+    def test_tls_certfile_defaults_to_none(self, tmp_path: Path):
+        """tls_certfile defaults to None."""
+        from amplifierd.config import DaemonSettings
+
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.tls_certfile is None
+
+    def test_auth_enabled_defaults_to_false(self, tmp_path: Path):
+        """auth_enabled defaults to False."""
+        from amplifierd.config import DaemonSettings
+
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.auth_enabled is False
+
+    def test_tls_mode_from_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """AMPLIFIERD_TLS_MODE env var overrides default."""
+        from amplifierd.config import DaemonSettings
+
+        monkeypatch.setenv("AMPLIFIERD_TLS_MODE", "auto")
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.tls_mode == "auto"
+
+    def test_auth_enabled_from_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """AMPLIFIERD_AUTH_ENABLED env var overrides default."""
+        from amplifierd.config import DaemonSettings
+
+        monkeypatch.setenv("AMPLIFIERD_AUTH_ENABLED", "true")
+        settings = DaemonSettings(_settings_dir=tmp_path)
+        assert settings.auth_enabled is True

--- a/tests/test_security_certs.py
+++ b/tests/test_security_certs.py
@@ -1,0 +1,59 @@
+"""Tests for self-signed certificate generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from amplifierd.security.certs import generate_self_signed_cert
+
+
+@pytest.mark.unit
+class TestGenerateSelfSignedCert:
+    """Tests for generate_self_signed_cert()."""
+
+    def test_reuses_existing_cert(self, tmp_path: Path):
+        """If cert and key already exist, returns them without regenerating."""
+        cert_dir = tmp_path / "certs"
+        cert_dir.mkdir()
+        cert = cert_dir / "self-signed.pem"
+        key = cert_dir / "self-signed-key.pem"
+        cert.write_text("CERT")
+        key.write_text("KEY")
+
+        result = generate_self_signed_cert(cert_dir)
+        assert result == (cert, key)
+
+    def test_generates_via_openssl(self, tmp_path: Path):
+        """Generates cert via openssl CLI when available."""
+        cert_dir = tmp_path / "certs"
+
+        # Simulate openssl writing files
+        def fake_openssl(*args, **kwargs):
+            cert_dir.mkdir(parents=True, exist_ok=True)
+            (cert_dir / "self-signed.pem").write_text("CERT")
+            (cert_dir / "self-signed-key.pem").write_text("KEY")
+            from subprocess import CompletedProcess
+
+            return CompletedProcess(args=[], returncode=0)
+
+        with patch("amplifierd.security.certs.subprocess.run", side_effect=fake_openssl):
+            cert_path, key_path = generate_self_signed_cert(cert_dir)
+
+        assert cert_path.exists()
+        assert key_path.exists()
+
+    def test_raises_when_no_backend_available(self, tmp_path: Path):
+        """Raises RuntimeError when neither openssl nor cryptography is available."""
+        cert_dir = tmp_path / "certs"
+
+        with (
+            patch(
+                "amplifierd.security.certs.subprocess.run", side_effect=FileNotFoundError
+            ),
+            patch("amplifierd.security.certs._generate_via_cryptography", return_value=False),
+        ):
+            with pytest.raises(RuntimeError, match="Cannot generate self-signed certificate"):
+                generate_self_signed_cert(cert_dir)

--- a/tests/test_security_middleware.py
+++ b/tests/test_security_middleware.py
@@ -1,0 +1,104 @@
+"""Tests for API key authentication middleware."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from amplifierd.security.middleware import ApiKeyMiddleware, is_localhost
+
+
+@pytest.mark.unit
+class TestIsLocalhost:
+    """Tests for localhost detection."""
+
+    def test_ipv4_localhost(self):
+        assert is_localhost("127.0.0.1") is True
+
+    def test_ipv6_localhost(self):
+        assert is_localhost("::1") is True
+
+    def test_localhost_string(self):
+        assert is_localhost("localhost") is True
+
+    def test_none_is_localhost(self):
+        assert is_localhost(None) is True
+
+    def test_remote_ip_is_not_localhost(self):
+        assert is_localhost("192.168.1.100") is False
+
+    def test_zero_zero_is_not_localhost(self):
+        assert is_localhost("0.0.0.0") is False
+
+
+def _make_app(api_key: str) -> FastAPI:
+    """Create a minimal FastAPI app with ApiKeyMiddleware for testing."""
+    app = FastAPI()
+    app.add_middleware(ApiKeyMiddleware, api_key=api_key)
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.get("/sessions")
+    async def sessions():
+        return {"sessions": []}
+
+    return app
+
+
+@pytest.mark.unit
+class TestApiKeyMiddleware:
+    """Tests for ApiKeyMiddleware."""
+
+    def test_valid_api_key_passes(self):
+        """Request with valid Bearer token passes through."""
+        app = _make_app("test-secret")
+        client = TestClient(app)
+        with patch("amplifierd.security.middleware.is_localhost", return_value=False):
+            resp = client.get("/sessions", headers={"Authorization": "Bearer test-secret"})
+        assert resp.status_code == 200
+
+    def test_missing_api_key_rejected(self):
+        """Request without Authorization header is rejected."""
+        app = _make_app("test-secret")
+        client = TestClient(app)
+        with patch("amplifierd.security.middleware.is_localhost", return_value=False):
+            resp = client.get("/sessions")
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid or missing API key"
+
+    def test_wrong_api_key_rejected(self):
+        """Request with wrong API key is rejected."""
+        app = _make_app("test-secret")
+        client = TestClient(app)
+        with patch("amplifierd.security.middleware.is_localhost", return_value=False):
+            resp = client.get("/sessions", headers={"Authorization": "Bearer wrong-key"})
+        assert resp.status_code == 401
+
+    def test_public_path_bypasses_auth(self):
+        """Public paths like /health bypass API key check."""
+        app = _make_app("test-secret")
+        client = TestClient(app)
+        with patch("amplifierd.security.middleware.is_localhost", return_value=False):
+            resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_non_bearer_auth_rejected(self):
+        """Non-Bearer auth scheme is rejected."""
+        app = _make_app("test-secret")
+        client = TestClient(app)
+        with patch("amplifierd.security.middleware.is_localhost", return_value=False):
+            resp = client.get("/sessions", headers={"Authorization": "Basic dXNlcjpwYXNz"})
+        assert resp.status_code == 401
+
+    def test_localhost_bypasses_auth(self):
+        """Localhost requests bypass API key check entirely."""
+        app = _make_app("test-secret")
+        client = TestClient(app)
+        with patch("amplifierd.security.middleware.is_localhost", return_value=True):
+            resp = client.get("/sessions")
+        assert resp.status_code == 200

--- a/tests/test_security_origins.py
+++ b/tests/test_security_origins.py
@@ -1,0 +1,52 @@
+"""Tests for dynamic CORS origin builder."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from amplifierd.security.origins import build_allowed_origins, is_origin_allowed
+
+
+@pytest.mark.unit
+class TestBuildAllowedOrigins:
+    """Tests for build_allowed_origins()."""
+
+    def test_always_includes_localhost(self):
+        with patch("amplifierd.security.origins.get_dns_name", return_value=None):
+            origins = build_allowed_origins()
+        assert "localhost" in origins
+        assert "127.0.0.1" in origins
+
+    def test_includes_tailscale_dns(self):
+        with patch(
+            "amplifierd.security.origins.get_dns_name",
+            return_value="myhost.tail1234.ts.net",
+        ):
+            origins = build_allowed_origins()
+        assert "myhost.tail1234.ts.net" in origins
+
+    def test_includes_extras(self):
+        with patch("amplifierd.security.origins.get_dns_name", return_value=None):
+            origins = build_allowed_origins(extra=["https://custom.example.com"])
+        assert "https://custom.example.com" in origins
+
+    def test_deduplicates(self):
+        with patch("amplifierd.security.origins.get_dns_name", return_value=None):
+            origins = build_allowed_origins(extra=["localhost"])
+        assert origins.count("localhost") == 1
+
+
+@pytest.mark.unit
+class TestIsOriginAllowed:
+    """Tests for is_origin_allowed()."""
+
+    def test_none_origin_always_allowed(self):
+        assert is_origin_allowed(None, {"localhost"}) is True
+
+    def test_matching_origin_allowed(self):
+        assert is_origin_allowed("https://myhost.tail1234.ts.net", {"tail1234.ts.net"}) is True
+
+    def test_non_matching_origin_rejected(self):
+        assert is_origin_allowed("https://evil.com", {"localhost", "tail1234.ts.net"}) is False

--- a/tests/test_security_tailscale.py
+++ b/tests/test_security_tailscale.py
@@ -1,0 +1,108 @@
+"""Tests for Tailscale integration."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from amplifierd.security.tailscale import get_dns_name, provision_cert, start_serve
+
+
+@pytest.mark.unit
+class TestGetDnsName:
+    """Tests for get_dns_name()."""
+
+    def test_returns_dns_name_when_connected(self):
+        status = {"BackendState": "Running", "Self": {"DNSName": "myhost.tail1234.ts.net."}}
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=json.dumps(status))
+        with patch("amplifierd.security.tailscale.subprocess.run", return_value=result):
+            assert get_dns_name() == "myhost.tail1234.ts.net"
+
+    def test_returns_none_when_not_running(self):
+        status = {"BackendState": "Stopped", "Self": {"DNSName": "myhost.tail1234.ts.net."}}
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=json.dumps(status))
+        with patch("amplifierd.security.tailscale.subprocess.run", return_value=result):
+            assert get_dns_name() is None
+
+    def test_returns_none_when_tailscale_not_installed(self):
+        with patch("amplifierd.security.tailscale.subprocess.run", side_effect=FileNotFoundError):
+            assert get_dns_name() is None
+
+    def test_returns_none_on_nonzero_exit(self):
+        result = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="error")
+        with patch("amplifierd.security.tailscale.subprocess.run", return_value=result):
+            assert get_dns_name() is None
+
+    def test_returns_none_on_timeout(self):
+        with patch(
+            "amplifierd.security.tailscale.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="tailscale", timeout=5),
+        ):
+            assert get_dns_name() is None
+
+
+@pytest.mark.unit
+class TestStartServe:
+    """Tests for start_serve()."""
+
+    def test_returns_url_on_success(self):
+        with (
+            patch(
+                "amplifierd.security.tailscale.get_dns_name",
+                return_value="myhost.tail1234.ts.net",
+            ),
+            patch(
+                "amplifierd.security.tailscale.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+            ),
+        ):
+            assert start_serve(8410) == "https://myhost.tail1234.ts.net"
+
+    def test_returns_none_when_tailscale_not_available(self):
+        with patch("amplifierd.security.tailscale.get_dns_name", return_value=None):
+            assert start_serve(8410) is None
+
+    def test_returns_none_on_serve_failure(self):
+        with (
+            patch(
+                "amplifierd.security.tailscale.get_dns_name",
+                return_value="myhost.tail1234.ts.net",
+            ),
+            patch(
+                "amplifierd.security.tailscale.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=[], returncode=1, stdout="", stderr="some error"
+                ),
+            ),
+        ):
+            assert start_serve(8410) is None
+
+
+@pytest.mark.unit
+class TestProvisionCert:
+    """Tests for provision_cert()."""
+
+    def test_returns_none_when_tailscale_not_available(self, tmp_path: Path):
+        with patch("amplifierd.security.tailscale.get_dns_name", return_value=None):
+            assert provision_cert(tmp_path / "certs") is None
+
+    def test_returns_paths_on_success(self, tmp_path: Path):
+        cert_dir = tmp_path / "certs"
+        with (
+            patch(
+                "amplifierd.security.tailscale.get_dns_name",
+                return_value="myhost.tail1234.ts.net",
+            ),
+            patch(
+                "amplifierd.security.tailscale.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+            ),
+        ):
+            result = provision_cert(cert_dir)
+        assert result is not None
+        assert result[0] == cert_dir / "myhost.tail1234.ts.net.crt"
+        assert result[1] == cert_dir / "myhost.tail1234.ts.net.key"

--- a/tests/test_security_tls.py
+++ b/tests/test_security_tls.py
@@ -1,0 +1,91 @@
+"""Tests for TLS orchestration (resolve_tls)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from amplifierd.security.tls import resolve_tls
+
+
+@pytest.mark.unit
+class TestResolveTls:
+    """Tests for resolve_tls() — the Tailscale/TLS mutual exclusion orchestrator."""
+
+    def test_off_returns_empty(self):
+        """tls_mode='off' returns empty dict (no TLS)."""
+        settings = MagicMock()
+        settings.tls_mode = "off"
+        assert resolve_tls(settings, 8410) == {}
+
+    def test_tailscale_serve_skips_native_tls(self):
+        """When Tailscale serve is active, returns empty (Tailscale handles HTTPS)."""
+        settings = MagicMock()
+        settings.tls_mode = "auto"
+        settings.home_dir = Path("/tmp/test")
+
+        with (
+            patch(
+                "amplifierd.security.tls.tailscale.start_serve",
+                return_value="https://myhost.ts.net",
+            ),
+            patch("amplifierd.security.tls.atexit"),
+        ):
+            result = resolve_tls(settings, 8410)
+
+        assert result == {}
+
+    def test_auto_falls_back_to_self_signed(self):
+        """When Tailscale unavailable, auto mode generates self-signed cert."""
+        settings = MagicMock()
+        settings.tls_mode = "auto"
+        settings.home_dir = Path("/tmp/test")
+
+        cert = Path("/tmp/test/certs/self-signed.pem")
+        key = Path("/tmp/test/certs/self-signed-key.pem")
+
+        with (
+            patch("amplifierd.security.tls.tailscale.start_serve", return_value=None),
+            patch("amplifierd.security.tls.tailscale.provision_cert", return_value=None),
+            patch(
+                "amplifierd.security.tls.certs.generate_self_signed_cert", return_value=(cert, key)
+            ),
+        ):
+            result = resolve_tls(settings, 8410)
+
+        assert result == {"ssl_certfile": str(cert), "ssl_keyfile": str(key)}
+
+    def test_manual_returns_provided_paths(self, tmp_path: Path):
+        """manual mode returns the provided certfile/keyfile."""
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        cert.write_text("CERT")
+        key.write_text("KEY")
+
+        settings = MagicMock()
+        settings.tls_mode = "manual"
+        settings.tls_certfile = str(cert)
+        settings.tls_keyfile = str(key)
+
+        # Manual mode doesn't probe Tailscale serve — goes straight to cert validation
+        with patch("amplifierd.security.tls.tailscale.start_serve", return_value=None):
+            result = resolve_tls(settings, 8410)
+
+        assert result == {"ssl_certfile": str(cert), "ssl_keyfile": str(key)}
+
+    def test_manual_missing_files_raises(self):
+        """manual mode with missing cert/key files raises UsageError."""
+        import click
+
+        settings = MagicMock()
+        settings.tls_mode = "manual"
+        settings.tls_certfile = "/nonexistent/cert.pem"
+        settings.tls_keyfile = "/nonexistent/key.pem"
+
+        with (
+            patch("amplifierd.security.tls.tailscale.start_serve", return_value=None),
+            pytest.raises(click.UsageError, match="--ssl-certfile.*--ssl-keyfile"),
+        ):
+            resolve_tls(settings, 8410)

--- a/uv.lock
+++ b/uv.lock
@@ -1,17 +1,34 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
 name = "amplifier-core"
-version = "1.0.7"
-source = { git = "https://github.com/microsoft/amplifier-core#580ecc056a83f2252f10a9d5c3faae554f53dead" }
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tomli" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/05ab33db532c2b2b0fcae4ff41259101bb00e4d13e0b98cc0442be6ac97a/amplifier_core-1.1.1.tar.gz", hash = "sha256:56ad6c1d47f5bafb5d548e75e6f215cd95f9ff9bdc4bcfbfc38315543792f320", size = 299697, upload-time = "2026-03-09T13:14:43.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/0f/3f0068899a5ef8052d04ec4853f5fd1a5bf7c38bb43eca3b4abc9144eb3a/amplifier_core-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:250e6908e4719b9b99bf7d42dbbf8d8984c6cd3b3d4b172d21ba6cb21b6a46d5", size = 6802772, upload-time = "2026-03-09T13:14:04.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/9c/cb27e8f9c0d4e5b6a0e74a44e4917540194ad17e3f8d14bd8bb461da295a/amplifier_core-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c74041328073383dd2f3434bbe1d3d89c8d345da4143b521824a9e5e6205f5c1", size = 7000430, upload-time = "2026-03-09T13:14:06.047Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/68/7cb3589c3be42cf81b69a41c4b93ffde3fee514c08c5ca0cdfc09b6cbee5/amplifier_core-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af41f726ff2e1804938ae968d0bc580f2d2457203d278e208a0b9ece1efa4422", size = 8079235, upload-time = "2026-03-09T13:14:08.981Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/953d8e6a9aafae73bc87ff550f813ede926755e2a72260ab9fb0e3d90546/amplifier_core-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f3a97003cf33c86e4f980c6fd73b3d745e669867167da99669b541a83f85860", size = 8454248, upload-time = "2026-03-09T13:14:12.64Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e4/bb88b887e78cecc604c09ad6634287fa8d479048ebc5627026701094074f/amplifier_core-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f690c10250654f87daf4928f1918183838d3ce0a02b7d4b6be7e6fc4252543fa", size = 6802851, upload-time = "2026-03-09T13:14:15.07Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b7/e46d9842cc959cef5051908b29ab532dac46a464bc3a1ac2f9106e85ada3/amplifier_core-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7e4a207fe59fd86686d82b13128200a89e6addc3a28cc62f7ac18891a551efb1", size = 6999052, upload-time = "2026-03-09T13:14:16.836Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d8/c77f48491b1c8d40cadbc2b8daea84b3d54144512c639904c504644394b9/amplifier_core-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a473ee6eeec40420a6e211b35e0d6bb70978432e9c12cb04e7dfec4062380395", size = 8078458, upload-time = "2026-03-09T13:14:19.691Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d1/d766d24395741888b21067003058d167ff00ad9f6c1387f353bfad84e9c9/amplifier_core-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:c2b0c510ef06e7dc95dba293bacef519da5a92add4eaba3eb0c58c2d0a470538", size = 8453868, upload-time = "2026-03-09T13:14:21.667Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7c/8ba721bf5e879ce684c0ced2e916a7e84ce03300021ee4b500c16d915b6f/amplifier_core-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e6e6f334d7e487aa93f606004c9f9d428fcc95f4f5a6d7707f4e4fc3e630311", size = 6994071, upload-time = "2026-03-09T13:14:23.957Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ca/cbc16d2498d3d2ae3c522207589c5109d7793bfd3df39b033317ee5d74fa/amplifier_core-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:832856b3c99fc46c95061ac6ce62d49fb26d930b57cc5439711876c252f9361f", size = 6801425, upload-time = "2026-03-09T13:14:25.881Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cb/1f8a58de32c99d49afb6c76b5138c2655d607f257167e64f7b64f8271c47/amplifier_core-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15951a70632776c812cf0533a2f1aeee00b0cb32ba3a5b2f0b1a649b5958b847", size = 6998415, upload-time = "2026-03-09T13:14:27.786Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f5/a5cd527889c058743568cacbfcef7418d6b73744ceb4d663746b7ac62365/amplifier_core-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:417f8960ce938221ac530f2541f242ce85b6146c9fbaa65fefc3dee556a6cd0b", size = 8077700, upload-time = "2026-03-09T13:14:30.004Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b0/11b418707a1a5eaa97877c1a042366854e86348f95f219f24548d6e988dc/amplifier_core-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:f4658e1fcd681b865dc6737ee8ebdf5eedb2dcd6d0fc9bc1e3382aa2014e6ce3", size = 8453164, upload-time = "2026-03-09T13:14:33.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/45/8f0e4dbce761d291af98989a13586f1ee91837b87936a4b6bfe35509e484/amplifier_core-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f030f9711d802ffa0bc51a7fd7c4e2f7e5760aec8339d2bc9e764e491379aec", size = 6994097, upload-time = "2026-03-09T13:14:35.864Z" },
 ]
 
 [[package]]
@@ -51,7 +68,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "amplifier-core", git = "https://github.com/microsoft/amplifier-core" },
+    { name = "amplifier-core", specifier = ">=1.1.1" },
     { name = "amplifier-foundation", git = "https://github.com/microsoft/amplifier-foundation" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },


### PR DESCRIPTION
## Summary

Adds an opt-in security layer to amplifierd. All defaults are unchanged — `amplifierd serve` with no flags behaves exactly as before (localhost, no TLS, no auth, wildcard CORS).

## What's included

### Configurable CORS (Slice 1)
- `allowed_origins` field on `DaemonSettings` — replaces hardcoded `["*"]` in `create_app()`
- Configurable via `AMPLIFIERD_ALLOWED_ORIGINS` env var or `settings.json`
- Default `["*"]` preserves current behavior

### API key authentication (Slice 1)
- `ApiKeyMiddleware` in `security/middleware.py` — opt-in when `api_key` is set
- Localhost requests always bypass (same security posture as today for local clients)
- Public paths (`/health`, `/info`, `/docs`) always bypass
- Bearer token auth for non-localhost requests
- `--api-key` CLI flag and `AMPLIFIERD_API_KEY` env var

### TLS support (Slice 2)
- `security/tailscale.py` — auto-detect Tailscale, `tailscale serve` reverse proxy, `tailscale cert` provisioning
- `security/certs.py` — self-signed cert generation (openssl CLI → cryptography library fallback)
- `security/tls.py` — orchestrator enforcing Tailscale/native-TLS mutual exclusion invariant
- `--tls auto|off|manual`, `--ssl-certfile`, `--ssl-keyfile` CLI flags
- `ssl_kwargs` passed through to `uvicorn.run()`

### Dynamic origin builder (Slice 2)
- `security/origins.py` — builds CORS allow-list from localhost + Tailscale DNS + system hostname
- Available for consumers to use when configuring `allowed_origins`

### Settings additions
- `allowed_origins`, `api_key`, `tls_mode`, `tls_certfile`, `tls_keyfile`, `auth_enabled`
- All via `AMPLIFIERD_*` env vars, `settings.json`, and CLI flags
- All default to current behavior (off/none/wildcard)

## Design principle

Generic HTTP security lives in amplifierd. Consumer-specific auth (e.g., PAM login for distro) lives in plugins. This PR provides the infrastructure; distro will add a PAM auth plugin that uses these primitives.

## Tailscale/TLS mutual exclusion

`tailscale serve` proxies HTTPS→HTTP. If uvicorn also has native TLS, the connection breaks. The `resolve_tls()` orchestrator structurally prevents this — native TLS resolution only runs when Tailscale serve is not active.

## Testing

- 55 new tests across 6 test files
- 516 total tests passing
- Zero pre-existing tests broken

## Files changed

**New:**
- `src/amplifierd/security/__init__.py`
- `src/amplifierd/security/middleware.py` — API key middleware + localhost bypass
- `src/amplifierd/security/tailscale.py` — Tailscale integration
- `src/amplifierd/security/certs.py` — self-signed cert generation
- `src/amplifierd/security/tls.py` — TLS orchestrator
- `src/amplifierd/security/origins.py` — dynamic origin builder
- `tests/test_security_middleware.py`
- `tests/test_security_tailscale.py`
- `tests/test_security_certs.py`
- `tests/test_security_tls.py`
- `tests/test_security_origins.py`

**Modified:**
- `src/amplifierd/config.py` — 6 new settings fields
- `src/amplifierd/app.py` — settings-driven CORS, optional API key middleware
- `src/amplifierd/cli.py` — 4 new flags, `ssl_kwargs` to uvicorn
- `tests/test_config.py` — 11 new tests
- `tests/test_cli.py` — 7 new tests + resolve_tls patches for existing tests