### PR TITLE
fix: forward child session streaming events to parent SSE stream

### DIFF
--- a/src/amplifierd/spawn.py
+++ b/src/amplifierd/spawn.py
@@ -3,15 +3,21 @@
 Registers the ``session.spawn`` capability on a coordinator so the
 ``delegate`` and ``recipes`` tools can spawn sub-sessions.
 
-Ported from distro-server's spawn_registration.py, simplified for
-amplifierd (voice-specific options like exclude_tools and event_forwarder
-are omitted).
+When *session_manager* and *parent_handle* are provided, child sessions
+are wrapped in a :class:`SessionHandle` and wired into the EventBus tree
+so their streaming events (``content_block:*``, ``thinking:*``, ``tool:*``)
+appear on the parent session's SSE stream.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from amplifierd.state.session_handle import SessionHandle
+    from amplifierd.state.session_manager import SessionManager
 
 logger = logging.getLogger(__name__)
 
@@ -23,15 +29,26 @@ def register_spawn_capability(
     session: Any,
     prepared: Any,
     session_id: str,
+    *,
+    session_manager: SessionManager | None = None,
+    parent_handle: SessionHandle | None = None,
 ) -> None:
     """Register ``session.spawn`` capability on *session*'s coordinator.
 
     Args:
         session:    AmplifierSession whose coordinator receives the capability.
         prepared:   PreparedBundle used to create *session*.  Its ``spawn()``
-                    method and ``bundle.agents`` registry are used for
+                    method, ``bundle``, and ``resolver`` are used for
                     sub-session creation.
         session_id: ID of *session* (for logging only).
+        session_manager:
+                    When provided together with *parent_handle*, child sessions
+                    are registered in the SessionManager and wired into the
+                    EventBus tree so their streaming events are visible to SSE
+                    subscribers.
+        parent_handle:
+                    SessionHandle of *session*.  Used to call
+                    ``register_child()`` for EventBus tree propagation.
     """
     from amplifier_foundation import Bundle  # type: ignore[import]
 
@@ -77,8 +94,7 @@ def register_spawn_capability(
                 list(configs.keys())
                 + (
                     list(prepared.bundle.agents.keys())
-                    if hasattr(prepared, "bundle")
-                    and hasattr(prepared.bundle, "agents")
+                    if hasattr(prepared, "bundle") and hasattr(prepared.bundle, "agents")
                     else []
                 )
             )
@@ -92,10 +108,7 @@ def register_spawn_capability(
             providers=config.get("providers", []),
             tools=config.get("tools", []),
             hooks=list(config.get("hooks", [])),
-            instruction=(
-                config.get("instruction")
-                or config.get("system", {}).get("instruction")
-            ),
+            instruction=(config.get("instruction") or config.get("system", {}).get("instruction")),
         )
 
         logger.debug(
@@ -105,7 +118,24 @@ def register_spawn_capability(
             session_id,
         )
 
-        # --- Delegate to PreparedBundle.spawn() ---
+        # --- Spawn with or without EventBus integration ---
+        if session_manager is not None and parent_handle is not None:
+            return await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=child_bundle,
+                agent_name=agent_name,
+                instruction=instruction,
+                parent_session=parent_session,
+                sub_session_id=sub_session_id,
+                orchestrator_config=orchestrator_config,
+                parent_messages=parent_messages,
+                provider_preferences=provider_preferences,
+                self_delegation_depth=self_delegation_depth,
+                session_manager=session_manager,
+                parent_handle=parent_handle,
+            )
+
+        # Fallback: delegate to PreparedBundle.spawn() without event forwarding.
         return await prepared.spawn(
             child_bundle=child_bundle,
             instruction=instruction,
@@ -119,3 +149,203 @@ def register_spawn_capability(
 
     coordinator.register_capability("session.spawn", spawn_fn)
     logger.info("session.spawn capability registered for session %s", session_id)
+
+
+# ------------------------------------------------------------------
+# Internal helper
+# ------------------------------------------------------------------
+
+
+async def _spawn_with_event_forwarding(
+    *,
+    prepared: Any,
+    child_bundle: Any,
+    agent_name: str,
+    instruction: str,
+    parent_session: Any,
+    sub_session_id: str | None,
+    orchestrator_config: dict[str, Any] | None,
+    parent_messages: list[dict[str, Any]] | None,
+    provider_preferences: list[Any] | None,
+    self_delegation_depth: int,
+    session_manager: SessionManager,
+    parent_handle: SessionHandle,
+) -> dict[str, Any]:
+    """Spawn a child session with EventBus integration for SSE streaming.
+
+    Replicates the essential logic of ``PreparedBundle.spawn()`` but wraps
+    the child session in a ``SessionHandle`` so its streaming events are
+    forwarded to the EventBus.  This allows SSE subscribers on the parent
+    session (``GET /events?session=<parent_id>``) to receive child session
+    events in real time.
+
+    Reference implementations:
+        - ``amplifier_foundation/bundle.py`` — ``PreparedBundle.spawn()``
+        - ``amplifier-app-cli/session_spawner.py`` — ``spawn_sub_session()``
+    """
+    from amplifier_core import AmplifierSession, HookResult  # type: ignore[import]
+
+    # 1. Compose child bundle with parent bundle
+    effective_bundle = prepared.bundle.compose(child_bundle)
+
+    # 2. Create mount plan from composed bundle
+    child_mount_plan = effective_bundle.to_mount_plan()
+
+    # 3. Merge orchestrator config override
+    if orchestrator_config:
+        orch = child_mount_plan.setdefault("orchestrator", {})
+        orch.setdefault("config", {}).update(orchestrator_config)
+
+    # 4. Apply provider preferences (fallback chain)
+    if provider_preferences:
+        from amplifier_foundation import (  # type: ignore[import]
+            apply_provider_preferences_with_resolution,
+        )
+
+        child_mount_plan = await apply_provider_preferences_with_resolution(
+            child_mount_plan,
+            provider_preferences,
+            parent_session.coordinator if parent_session else None,
+        )
+
+    # 5. Create child AmplifierSession
+    child_session = AmplifierSession(
+        child_mount_plan,
+        session_id=sub_session_id,
+        parent_id=parent_session.session_id if parent_session else None,
+        approval_system=(
+            getattr(
+                getattr(parent_session, "coordinator", None),
+                "approval_system",
+                None,
+            )
+            if parent_session
+            else None
+        ),
+        display_system=(
+            getattr(
+                getattr(parent_session, "coordinator", None),
+                "display_system",
+                None,
+            )
+            if parent_session
+            else None
+        ),
+    )
+
+    # 6. Mount module resolver from parent PreparedBundle
+    await child_session.coordinator.mount("module-source-resolver", prepared.resolver)
+
+    # 7. Inherit working directory from parent session
+    if parent_session:
+        parent_wd = parent_session.coordinator.get_capability("session.working_dir")
+        effective_cwd = (
+            Path(parent_wd)
+            if parent_wd
+            else (getattr(prepared.bundle, "base_path", None) or Path.cwd())
+        )
+    else:
+        effective_cwd = getattr(prepared.bundle, "base_path", None) or Path.cwd()
+    child_session.coordinator.register_capability(
+        "session.working_dir",
+        str(Path(effective_cwd).resolve()),
+    )
+
+    # 8. Initialize child session (mounts modules from mount plan)
+    await child_session.initialize()
+
+    # 9. Register self-delegation depth for recursion limiting
+    if self_delegation_depth > 0:
+        child_session.coordinator.register_capability(
+            "self_delegation_depth",
+            self_delegation_depth,
+        )
+
+    # 10. Inject parent messages for context inheritance (new sessions only)
+    if parent_messages and not sub_session_id:
+        child_context = child_session.coordinator.get("context")
+        if child_context and hasattr(child_context, "set_messages"):
+            await child_context.set_messages(parent_messages)
+
+    # 11. Set up system prompt from composed bundle
+    try:
+        if effective_bundle.instruction or getattr(effective_bundle, "context", None):
+            factory = prepared._create_system_prompt_factory(
+                effective_bundle,
+                child_session,
+            )
+            context = child_session.coordinator.get("context")
+            if context and hasattr(context, "set_system_prompt_factory"):
+                await context.set_system_prompt_factory(factory)
+            elif context:
+                resolved_prompt = await factory()
+                await context.add_message(
+                    {"role": "system", "content": resolved_prompt},
+                )
+    except (AttributeError, TypeError):
+        logger.debug(
+            "Could not set system prompt via _create_system_prompt_factory",
+            exc_info=True,
+        )
+
+    # ------------------------------------------------------------------
+    # EventBus integration
+    # ------------------------------------------------------------------
+
+    # 12. Register child in SessionManager — creates a SessionHandle whose
+    #     __init__ calls _wire_events(), hooking all kernel events to EventBus.
+    child_handle = session_manager.register(
+        session=child_session,
+        prepared_bundle=None,
+        bundle_name=agent_name,
+    )
+
+    # 13. Wire parent -> child in EventBus so SSE subscribers on the parent
+    #     session automatically receive child events via get_descendants().
+    parent_handle.register_child(child_session.session_id, agent_name)
+
+    # 14. Register spawn capability on child (enables recursive delegation)
+    register_spawn_capability(
+        child_session,
+        prepared,
+        child_session.session_id,
+        session_manager=session_manager,
+        parent_handle=child_handle,
+    )
+
+    # 15. Register temporary hook to capture orchestrator:complete metadata
+    completion_data: dict[str, Any] = {}
+    unregister_capture = None
+    hooks = getattr(child_session.coordinator, "hooks", None)
+    if hooks:
+
+        async def _capture_completion(
+            event: str,
+            data: dict[str, Any],
+        ) -> HookResult:
+            completion_data.update(data)
+            return HookResult(action="continue")
+
+        unregister_capture = hooks.register(
+            "orchestrator:complete",
+            _capture_completion,
+            priority=999,
+            name="_amplifierd_spawn_capture",
+        )
+
+    # 16. Execute via SessionHandle (sets correlation_id for event attribution)
+    try:
+        response = await child_handle.execute(instruction)
+    finally:
+        if unregister_capture:
+            unregister_capture()
+        # 17. Cleanup: remove child from SessionManager, teardown session
+        await session_manager.destroy(child_session.session_id)
+
+    return {
+        "output": response,
+        "session_id": child_session.session_id,
+        "status": completion_data.get("status", "success"),
+        "turn_count": completion_data.get("turn_count", 1),
+        "metadata": completion_data.get("metadata", {}),
+    }

--- a/src/amplifierd/state/session_manager.py
+++ b/src/amplifierd/state/session_manager.py
@@ -274,14 +274,6 @@ class SessionManager:
         else:
             slug = ""
 
-        # Register spawn capability so delegate tool can spawn sub-sessions
-        try:
-            from amplifierd.spawn import register_spawn_capability
-
-            register_spawn_capability(session, prepared, session.session_id)
-        except (ImportError, Exception):  # noqa: BLE001
-            logger.debug("Spawn capability registration skipped", exc_info=True)
-
         handle = self.register(
             session=session,
             prepared_bundle=prepared,
@@ -289,6 +281,23 @@ class SessionManager:
             working_dir=wd,
             project_id=slug,
         )
+
+        # Register spawn capability so delegate tool can spawn sub-sessions.
+        # Must happen AFTER register() so the parent_handle is available for
+        # EventBus tree wiring in child sessions.
+        try:
+            from amplifierd.spawn import register_spawn_capability
+
+            register_spawn_capability(
+                session,
+                prepared,
+                session.session_id,
+                session_manager=self,
+                parent_handle=handle,
+            )
+        except (ImportError, Exception):  # noqa: BLE001
+            logger.debug("Spawn capability registration skipped", exc_info=True)
+
         return handle
 
     async def resume(self, session_id: str) -> SessionHandle:
@@ -400,18 +409,10 @@ class SessionManager:
 
         register_persistence_hooks(session, session_dir)
 
-        # 7. Register spawn capability
-        try:
-            from amplifierd.spawn import register_spawn_capability
-
-            register_spawn_capability(session, prepared, session_id)
-        except (ImportError, Exception):  # noqa: BLE001
-            logger.debug("Spawn capability registration skipped", exc_info=True)
-
         # Determine project_id for index entry
         project_id = session_dir.parent.parent.name if session_dir.parent.name == "sessions" else ""
 
-        # 8. Register in SessionManager
+        # 7. Register in SessionManager
         handle = self.register(
             session=session,
             prepared_bundle=prepared,
@@ -419,6 +420,22 @@ class SessionManager:
             working_dir=working_dir,
             project_id=project_id,
         )
+
+        # 8. Register spawn capability (after register() so parent_handle
+        #    is available for EventBus tree wiring in child sessions)
+        try:
+            from amplifierd.spawn import register_spawn_capability
+
+            register_spawn_capability(
+                session,
+                prepared,
+                session_id,
+                session_manager=self,
+                parent_handle=handle,
+            )
+        except (ImportError, Exception):  # noqa: BLE001
+            logger.debug("Spawn capability registration skipped", exc_info=True)
+
         logger.info(
             "Session %s resumed (%d messages restored)",
             session_id,

--- a/tests/test_spawn_event_forwarding.py
+++ b/tests/test_spawn_event_forwarding.py
@@ -1,0 +1,736 @@
+"""Tests for child session event forwarding via spawn.py.
+
+Verifies that when the delegate/task tool spawns a sub-agent, the child
+session's streaming events appear on the parent session's SSE stream
+through the EventBus tree.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from amplifierd.state.event_bus import EventBus
+from amplifierd.state.session_handle import SessionHandle
+from amplifierd.state.session_manager import SessionManager
+from amplifierd.state.transport_event import TransportEvent
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _make_mock_session(
+    session_id: str = "parent-1",
+    parent_id: str | None = None,
+) -> MagicMock:
+    """Create a mock AmplifierSession with coordinator and hooks."""
+    session = MagicMock()
+    session.session_id = session_id
+    session.parent_id = parent_id
+    session.execute = AsyncMock(return_value="result-ok")
+    session.cleanup = AsyncMock()
+    session.initialize = AsyncMock()
+    session.coordinator = MagicMock()
+    session.coordinator.request_cancel = MagicMock()
+    session.coordinator.get_capability = MagicMock(return_value=None)
+    session.coordinator.mount = AsyncMock()
+    return session
+
+
+def _make_child_session(
+    session_id: str = "child-1",
+    parent_id: str = "parent-1",
+    execute_return: str = "child-response",
+) -> MagicMock:
+    """Create a mock AmplifierSession that simulates a child session.
+
+    The mock emits events through its hooks during execute() to simulate
+    what a real orchestrator does during execution.  The hooks dict is
+    shared with ``SessionHandle._wire_events()`` via a custom
+    ``hooks.register`` side-effect so that EventBus forwarding hooks
+    fire during ``execute()``.
+    """
+    session = MagicMock()
+    session.session_id = session_id
+    session.parent_id = parent_id
+    session.cleanup = AsyncMock()
+    session.initialize = AsyncMock()
+    session.coordinator = MagicMock()
+    session.coordinator.request_cancel = MagicMock()
+    session.coordinator.get_capability = MagicMock(return_value=None)
+    # get() returns None so the system-prompt / context-injection paths are skipped
+    session.coordinator.get = MagicMock(return_value=None)
+    session.coordinator.mount = AsyncMock()
+    session.coordinator.register_capability = MagicMock()
+
+    # Hooks: track registered handlers so we can fire them in execute()
+    _hooks: dict[str, list] = {}
+
+    def _register_hook(
+        event_name: str,
+        handler: Any,
+        priority: int = 0,
+        name: str | None = None,
+    ) -> Any:
+        _hooks.setdefault(event_name, []).append(handler)
+        return lambda: _hooks.get(event_name, []).remove(handler)
+
+    hooks_mock = MagicMock()
+    hooks_mock.register = MagicMock(side_effect=_register_hook)
+    session.coordinator.hooks = hooks_mock
+
+    # Also make getattr(coordinator, "hooks", None) work in _wire_events
+    session.coordinator.__dict__["hooks"] = hooks_mock
+
+    async def _execute(prompt: str) -> str:
+        """Simulate orchestrator execution: emit events through hooks.
+
+        Event names match amplifier_core.events.ALL_EVENTS:
+        content_block:start, content_block:delta, content_block:end,
+        orchestrator:complete.
+        """
+        for h in list(_hooks.get("content_block:start", [])):
+            await h("content_block:start", {"type": "text"})
+
+        for h in list(_hooks.get("content_block:delta", [])):
+            await h("content_block:delta", {"text": execute_return})
+
+        for h in list(_hooks.get("content_block:end", [])):
+            await h("content_block:end", {})
+
+        for h in list(_hooks.get("orchestrator:complete", [])):
+            await h(
+                "orchestrator:complete",
+                {"status": "success", "turn_count": 1, "metadata": {}},
+            )
+
+        return execute_return
+
+    session.execute = AsyncMock(side_effect=_execute)
+    return session
+
+
+def _make_mock_bundle(agents: dict[str, dict] | None = None) -> MagicMock:
+    """Create a mock Bundle with compose() and to_mount_plan()."""
+    bundle = MagicMock()
+    bundle.agents = agents or {}
+    bundle.base_path = None
+    bundle.instruction = None
+    bundle.context = None
+
+    composed = MagicMock()
+    composed.to_mount_plan = MagicMock(return_value={"tools": [], "hooks": []})
+    composed.instruction = None
+    composed.context = None
+    bundle.compose = MagicMock(return_value=composed)
+
+    return bundle
+
+
+def _make_mock_prepared(bundle: MagicMock | None = None) -> MagicMock:
+    """Create a mock PreparedBundle with bundle, resolver, and spawn()."""
+    prepared = MagicMock()
+    prepared.bundle = bundle or _make_mock_bundle()
+    prepared.resolver = MagicMock()
+    prepared.spawn = AsyncMock(
+        return_value={
+            "output": "fallback-response",
+            "session_id": "fallback-child",
+            "status": "success",
+            "turn_count": 1,
+            "metadata": {},
+        }
+    )
+    return prepared
+
+
+def _make_parent_handle(
+    session_id: str = "parent-1",
+    event_bus: EventBus | None = None,
+) -> SessionHandle:
+    """Create a real SessionHandle for a parent session."""
+    bus = event_bus or EventBus()
+    mock_session = _make_mock_session(session_id=session_id)
+    return SessionHandle(
+        session=mock_session,
+        prepared_bundle=None,
+        bundle_name="test-parent",
+        event_bus=bus,
+        working_dir="/tmp/test",
+    )
+
+
+def _make_manager(event_bus: EventBus | None = None) -> SessionManager:
+    """Create a real SessionManager with a real EventBus."""
+    from amplifierd.config import DaemonSettings
+
+    bus = event_bus or EventBus()
+    settings = DaemonSettings()
+    return SessionManager(event_bus=bus, settings=settings)
+
+
+# ------------------------------------------------------------------
+# Tests: register_spawn_capability signature
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRegisterSpawnCapability:
+    """Verify register_spawn_capability wires the spawn closure correctly."""
+
+    def test_registers_capability_on_coordinator(self):
+        """session.spawn capability is registered on the coordinator."""
+        session = _make_mock_session()
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import register_spawn_capability
+
+        register_spawn_capability(session, prepared, "parent-1")
+
+        session.coordinator.register_capability.assert_called_once()
+        args = session.coordinator.register_capability.call_args
+        assert args[0][0] == "session.spawn"
+        assert callable(args[0][1])
+
+    def test_accepts_session_manager_and_parent_handle(self):
+        """New keyword-only params don't break registration."""
+        bus = EventBus()
+        session = _make_mock_session()
+        prepared = _make_mock_prepared()
+        handle = _make_parent_handle(event_bus=bus)
+        manager = _make_manager(event_bus=bus)
+
+        from amplifierd.spawn import register_spawn_capability
+
+        register_spawn_capability(
+            session,
+            prepared,
+            "parent-1",
+            session_manager=manager,
+            parent_handle=handle,
+        )
+
+        session.coordinator.register_capability.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Tests: fallback path (no session_manager)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSpawnFallback:
+    """When session_manager is None, spawn_fn delegates to prepared.spawn()."""
+
+    async def test_falls_back_to_prepared_spawn(self):
+        """Without session_manager, spawn_fn calls prepared.spawn() directly."""
+        session = _make_mock_session()
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import register_spawn_capability
+
+        register_spawn_capability(session, prepared, "parent-1")
+
+        spawn_fn = session.coordinator.register_capability.call_args[0][1]
+
+        # agent_name="self" bypasses agent resolution; Bundle is constructed
+        # but prepared.spawn() is mocked, so the child_bundle value doesn't
+        # matter.
+        result = await spawn_fn(
+            agent_name="self",
+            instruction="do something",
+            parent_session=session,
+        )
+
+        assert result == prepared.spawn.return_value
+        prepared.spawn.assert_awaited_once()
+
+
+# ------------------------------------------------------------------
+# Tests: _spawn_with_event_forwarding
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSpawnWithEventForwarding:
+    """Verify _spawn_with_event_forwarding creates SessionHandle, wires
+    EventBus tree, and propagates child events to parent subscribers."""
+
+    async def test_child_registered_in_session_manager(self):
+        """Child session is registered in SessionManager during spawn,
+        then destroyed (cleaned up) after execution completes."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+        parent_handle = _make_parent_handle(session_id="parent-ef-1", event_bus=bus)
+        manager._sessions["parent-ef-1"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(session_id="child-ef-1", parent_id="parent-ef-1")
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import _spawn_with_event_forwarding
+
+        with patch("amplifier_core.AmplifierSession", return_value=child_session):
+            result = await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=MagicMock(),
+                agent_name="test-agent",
+                instruction="test instruction",
+                parent_session=_make_mock_session(session_id="parent-ef-1"),
+                sub_session_id="child-ef-1",
+                orchestrator_config=None,
+                parent_messages=None,
+                provider_preferences=None,
+                self_delegation_depth=0,
+                session_manager=manager,
+                parent_handle=parent_handle,
+            )
+
+        assert result["output"] == "child-response"
+        assert result["session_id"] == "child-ef-1"
+        assert result["status"] == "success"
+        # Child should be destroyed after execution
+        assert manager.get("child-ef-1") is None
+
+    async def test_child_wired_in_eventbus_tree(self):
+        """parent_handle.register_child() is called, wiring EventBus tree
+        BEFORE execution starts."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+        parent_handle = _make_parent_handle(session_id="parent-ef-2", event_bus=bus)
+        manager._sessions["parent-ef-2"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(session_id="child-ef-2", parent_id="parent-ef-2")
+        prepared = _make_mock_prepared()
+
+        # Check the tree is wired DURING execution (before execute returns)
+        tree_wired_during_execute = False
+        original_execute = child_session.execute.side_effect
+
+        async def _checking_execute(prompt: str) -> str:
+            nonlocal tree_wired_during_execute
+            tree_wired_during_execute = "child-ef-2" in bus.get_descendants("parent-ef-2")
+            return await original_execute(prompt)
+
+        child_session.execute = AsyncMock(side_effect=_checking_execute)
+
+        from amplifierd.spawn import _spawn_with_event_forwarding
+
+        with patch("amplifier_core.AmplifierSession", return_value=child_session):
+            await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=MagicMock(),
+                agent_name="test-agent",
+                instruction="test",
+                parent_session=_make_mock_session(session_id="parent-ef-2"),
+                sub_session_id="child-ef-2",
+                orchestrator_config=None,
+                parent_messages=None,
+                provider_preferences=None,
+                self_delegation_depth=0,
+                session_manager=manager,
+                parent_handle=parent_handle,
+            )
+
+        assert tree_wired_during_execute, (
+            "EventBus tree should be wired before child execution starts"
+        )
+
+    async def test_child_events_propagate_to_parent_subscriber(self):
+        """SSE subscriber on parent session receives child session events.
+
+        Events are published synchronously during execute(), so we start
+        the subscriber, run the spawn, yield control to let the subscriber
+        drain the queue, then verify.
+        """
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+        parent_handle = _make_parent_handle(session_id="parent-ef-3", event_bus=bus)
+        manager._sessions["parent-ef-3"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(
+            session_id="child-ef-3",
+            parent_id="parent-ef-3",
+            execute_return="streamed-text",
+        )
+        prepared = _make_mock_prepared()
+
+        # Collect events from parent's SSE stream
+        received: list[TransportEvent] = []
+
+        async def _consume() -> None:
+            async for event in bus.subscribe(session_id="parent-ef-3"):
+                received.append(event)
+                # content_block:start, delta, stop, orchestrator:complete
+                if len(received) >= 4:
+                    break
+
+        consumer_task = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)  # let subscriber register
+
+        from amplifierd.spawn import _spawn_with_event_forwarding
+
+        with patch("amplifier_core.AmplifierSession", return_value=child_session):
+            result = await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=MagicMock(),
+                agent_name="test-agent",
+                instruction="stream me",
+                parent_session=_make_mock_session(session_id="parent-ef-3"),
+                sub_session_id="child-ef-3",
+                orchestrator_config=None,
+                parent_messages=None,
+                provider_preferences=None,
+                self_delegation_depth=0,
+                session_manager=manager,
+                parent_handle=parent_handle,
+            )
+
+        # Events were published synchronously during execute(); yield so
+        # the consumer task can drain the queue entries.
+        await asyncio.sleep(0.1)
+
+        # If the consumer hasn't finished yet, give it a bounded wait.
+        # The events are already queued, so this should be near-instant.
+        try:
+            await asyncio.wait_for(consumer_task, timeout=2.0)
+        except TimeoutError:
+            # If we time out, the consumer didn't get enough events.
+            # Cancel and proceed — assertions below will report what we got.
+            consumer_task.cancel()
+            try:
+                await consumer_task
+            except asyncio.CancelledError:
+                pass
+
+        assert result["output"] == "streamed-text"
+
+        # Verify at least the core streaming events arrived
+        event_names = [e.event_name for e in received]
+        assert "content_block:start" in event_names, (
+            f"Expected content_block:start in {event_names}"
+        )
+        assert "content_block:delta" in event_names, (
+            f"Expected content_block:delta in {event_names}"
+        )
+        assert "content_block:end" in event_names, f"Expected content_block:end in {event_names}"
+
+        # All events should carry the child's session_id
+        for evt in received:
+            assert evt.session_id == "child-ef-3"
+
+    async def test_child_cleanup_after_execution(self):
+        """Child SessionHandle is destroyed after execution completes."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+        parent_handle = _make_parent_handle(session_id="parent-ef-4", event_bus=bus)
+        manager._sessions["parent-ef-4"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(session_id="child-ef-4", parent_id="parent-ef-4")
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import _spawn_with_event_forwarding
+
+        with patch("amplifier_core.AmplifierSession", return_value=child_session):
+            await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=MagicMock(),
+                agent_name="test-agent",
+                instruction="cleanup test",
+                parent_session=_make_mock_session(session_id="parent-ef-4"),
+                sub_session_id="child-ef-4",
+                orchestrator_config=None,
+                parent_messages=None,
+                provider_preferences=None,
+                self_delegation_depth=0,
+                session_manager=manager,
+                parent_handle=parent_handle,
+            )
+
+        assert manager.get("child-ef-4") is None
+        child_session.cleanup.assert_awaited_once()
+
+    async def test_child_cleanup_on_execution_failure(self):
+        """Child is cleaned up even when execution raises an exception."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+        parent_handle = _make_parent_handle(session_id="parent-ef-5", event_bus=bus)
+        manager._sessions["parent-ef-5"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(session_id="child-ef-5", parent_id="parent-ef-5")
+        child_session.execute = AsyncMock(side_effect=RuntimeError("boom"))
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import _spawn_with_event_forwarding
+
+        with (
+            patch("amplifier_core.AmplifierSession", return_value=child_session),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=MagicMock(),
+                agent_name="test-agent",
+                instruction="fail test",
+                parent_session=_make_mock_session(session_id="parent-ef-5"),
+                sub_session_id="child-ef-5",
+                orchestrator_config=None,
+                parent_messages=None,
+                provider_preferences=None,
+                self_delegation_depth=0,
+                session_manager=manager,
+                parent_handle=parent_handle,
+            )
+
+        assert manager.get("child-ef-5") is None
+        child_session.cleanup.assert_awaited_once()
+
+    async def test_completion_data_captured_in_result(self):
+        """orchestrator:complete hook data is included in the return dict."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+        parent_handle = _make_parent_handle(session_id="parent-ef-6", event_bus=bus)
+        manager._sessions["parent-ef-6"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(session_id="child-ef-6", parent_id="parent-ef-6")
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import _spawn_with_event_forwarding
+
+        with patch("amplifier_core.AmplifierSession", return_value=child_session):
+            result = await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=MagicMock(),
+                agent_name="test-agent",
+                instruction="completion test",
+                parent_session=_make_mock_session(session_id="parent-ef-6"),
+                sub_session_id="child-ef-6",
+                orchestrator_config=None,
+                parent_messages=None,
+                provider_preferences=None,
+                self_delegation_depth=0,
+                session_manager=manager,
+                parent_handle=parent_handle,
+            )
+
+        assert result["status"] == "success"
+        assert result["turn_count"] == 1
+        assert result["metadata"] == {}
+
+    async def test_recursive_spawn_capability_on_child(self):
+        """Child session gets its own session.spawn capability."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+        parent_handle = _make_parent_handle(session_id="parent-ef-7", event_bus=bus)
+        manager._sessions["parent-ef-7"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(session_id="child-ef-7", parent_id="parent-ef-7")
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import _spawn_with_event_forwarding
+
+        with patch("amplifier_core.AmplifierSession", return_value=child_session):
+            await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=MagicMock(),
+                agent_name="test-agent",
+                instruction="recursive test",
+                parent_session=_make_mock_session(session_id="parent-ef-7"),
+                sub_session_id="child-ef-7",
+                orchestrator_config=None,
+                parent_messages=None,
+                provider_preferences=None,
+                self_delegation_depth=0,
+                session_manager=manager,
+                parent_handle=parent_handle,
+            )
+
+        spawn_calls = [
+            c
+            for c in child_session.coordinator.register_capability.call_args_list
+            if c[0][0] == "session.spawn"
+        ]
+        assert len(spawn_calls) == 1, "Child should have session.spawn capability"
+
+    async def test_child_events_have_correlation_id(self):
+        """Events published from child session include a correlation_id."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+        parent_handle = _make_parent_handle(session_id="parent-ef-8", event_bus=bus)
+        manager._sessions["parent-ef-8"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(session_id="child-ef-8", parent_id="parent-ef-8")
+        prepared = _make_mock_prepared()
+
+        received: list[TransportEvent] = []
+
+        async def _consume() -> None:
+            async for event in bus.subscribe(session_id="parent-ef-8"):
+                received.append(event)
+                if len(received) >= 3:
+                    break
+
+        consumer_task = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)
+
+        from amplifierd.spawn import _spawn_with_event_forwarding
+
+        with patch("amplifier_core.AmplifierSession", return_value=child_session):
+            await _spawn_with_event_forwarding(
+                prepared=prepared,
+                child_bundle=MagicMock(),
+                agent_name="test-agent",
+                instruction="correlation test",
+                parent_session=_make_mock_session(session_id="parent-ef-8"),
+                sub_session_id="child-ef-8",
+                orchestrator_config=None,
+                parent_messages=None,
+                provider_preferences=None,
+                self_delegation_depth=0,
+                session_manager=manager,
+                parent_handle=parent_handle,
+            )
+
+        await asyncio.wait_for(consumer_task, timeout=2.0)
+
+        # SessionHandle.execute sets correlation_id before calling session.execute
+        for evt in received:
+            assert evt.correlation_id is not None
+            assert evt.correlation_id.startswith("prompt_child-ef-8_")
+
+
+# ------------------------------------------------------------------
+# Tests: end-to-end via spawn_fn
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSpawnFnEndToEnd:
+    """Test the full spawn_fn path through register_spawn_capability."""
+
+    async def test_spawn_fn_uses_event_forwarding_when_manager_available(self):
+        """spawn_fn takes the event-forwarding path when session_manager is set."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+
+        parent_session = _make_mock_session(session_id="parent-e2e-1")
+        parent_handle = _make_parent_handle(session_id="parent-e2e-1", event_bus=bus)
+        manager._sessions["parent-e2e-1"] = parent_handle  # noqa: SLF001
+
+        child_session = _make_child_session(
+            session_id="child-e2e-1",
+            parent_id="parent-e2e-1",
+            execute_return="e2e-result",
+        )
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import register_spawn_capability
+
+        register_spawn_capability(
+            parent_session,
+            prepared,
+            "parent-e2e-1",
+            session_manager=manager,
+            parent_handle=parent_handle,
+        )
+
+        spawn_fn = parent_session.coordinator.register_capability.call_args[0][1]
+
+        # Subscribe to parent to verify events flow
+        received: list[TransportEvent] = []
+
+        async def _consume() -> None:
+            async for event in bus.subscribe(session_id="parent-e2e-1"):
+                received.append(event)
+                if len(received) >= 3:
+                    break
+
+        consumer_task = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)
+
+        with patch("amplifier_core.AmplifierSession", return_value=child_session):
+            result = await spawn_fn(
+                agent_name="self",
+                instruction="e2e test",
+                parent_session=parent_session,
+            )
+
+        await asyncio.wait_for(consumer_task, timeout=2.0)
+
+        assert result["output"] == "e2e-result"
+        assert result["session_id"] == "child-e2e-1"
+
+        # prepared.spawn() should NOT have been called (event-forwarding path used)
+        prepared.spawn.assert_not_awaited()
+
+        # Events propagated through EventBus
+        event_names = [e.event_name for e in received]
+        assert "content_block:start" in event_names
+        assert "content_block:delta" in event_names
+
+    async def test_spawn_fn_falls_back_without_manager(self):
+        """spawn_fn uses prepared.spawn() when session_manager is None."""
+        parent_session = _make_mock_session(session_id="parent-e2e-2")
+        prepared = _make_mock_prepared()
+
+        from amplifierd.spawn import register_spawn_capability
+
+        register_spawn_capability(parent_session, prepared, "parent-e2e-2")
+
+        spawn_fn = parent_session.coordinator.register_capability.call_args[0][1]
+
+        result = await spawn_fn(
+            agent_name="self",
+            instruction="fallback test",
+            parent_session=parent_session,
+        )
+
+        prepared.spawn.assert_awaited_once()
+        assert result == prepared.spawn.return_value
+
+
+# ------------------------------------------------------------------
+# Tests: session_manager.create() passes new params
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionManagerSpawnWiring:
+    """Verify SessionManager.create() threads self and handle into
+    register_spawn_capability."""
+
+    async def test_create_passes_session_manager_and_handle(self):
+        """SessionManager.create() passes session_manager=self and
+        parent_handle=<created handle> to register_spawn_capability."""
+        bus = EventBus()
+        manager = _make_manager(event_bus=bus)
+
+        mock_bundle = MagicMock()
+        mock_bundle.prepare = AsyncMock()
+        mock_prepared = MagicMock()
+        mock_bundle.prepare.return_value = mock_prepared
+
+        mock_session = _make_mock_session(session_id="create-test-1")
+        mock_prepared.create_session = AsyncMock(return_value=mock_session)
+
+        manager._bundle_registry = MagicMock()  # noqa: SLF001
+        manager._bundle_registry.load = AsyncMock(return_value=mock_bundle)  # noqa: SLF001
+
+        # These are lazy-imported inside create(), so patch at the source module.
+        with (
+            patch("amplifierd.providers.inject_providers"),
+            patch("amplifierd.providers.load_provider_config", return_value={}),
+            patch("amplifierd.spawn.register_spawn_capability") as mock_register,
+        ):
+            handle = await manager.create(bundle_name="test-bundle")
+
+        mock_register.assert_called_once()
+        call_args = mock_register.call_args
+        assert call_args[0][0] is mock_session
+        assert call_args[0][1] is mock_prepared
+        assert call_args[0][2] == "create-test-1"
+        assert call_args[1]["session_manager"] is manager
+        assert call_args[1]["parent_handle"] is handle


### PR DESCRIPTION
## Summary

- Rewrote `spawn.py`'s spawn capability closure to replace the `PreparedBundle.spawn()` black-box call with manual child session lifecycle management: initialize → wrap in `SessionHandle` → register in `SessionManager` → wire `EventBus` tree → execute. Child streaming events (`content_block:*`, `thinking:*`, `tool:*`) now propagate to the parent session's SSE stream.
- Updated `session_manager.py` to call `register_spawn_capability()` **after** `self.register()` so the parent `SessionHandle` exists and can be passed as `parent_handle`.
- Added 14 tests covering capability registration, fallback to `prepared.spawn()`, child registration, EventBus wiring order, SSE propagation, cleanup on success/failure, completion data capture, recursive spawn capability on child, `correlation_id` threading, and `SessionManager.create()` wiring verification.

## Background

The HTTP-triggered `/sessions/{id}/spawn` route in `routes/agents.py` already handled child session wiring correctly. The spawn capability closure (used when an agent spawns a child programmatically) bypassed that infrastructure entirely — no `SessionHandle`, no `SessionManager` registration, no `EventBus` tree — making child events invisible to SSE clients. This fix brings the closure path to parity with the HTTP path.

## Test plan

- [x] 475 tests pass (461 existing + 14 new), 0 failures
- [x] Fallback to `prepared.spawn()` preserved when `session_manager`/`parent_handle` are absent
- [x] `uv.lock` excluded from this change

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)