### PR TITLE
feat: bundle prewarm at startup with /ready endpoint

### DIFF
--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -51,7 +51,9 @@ async def _prewarm(app: FastAPI) -> None:
         # event loop inside that thread via asyncio.run(). The main uvicorn loop
         # stays free and can respond to /ready, /health, etc. throughout.
         prepared = await asyncio.to_thread(lambda: asyncio.run(bundle.prepare()))
-        app.state.prepared_bundle = prepared
+        session_manager = getattr(app.state, "session_manager", None)
+        if session_manager:
+            session_manager.set_prepared_bundle(settings.default_bundle, prepared)
 
         app.state.bundles_ready.set()
         logger.info("Bundle pre-warmed and ready: %s", settings.default_bundle)
@@ -189,7 +191,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     app.state.bundles_ready = asyncio.Event()
     app.state.prewarm_task = None
     app.state.prewarm_error = None
-    app.state.prepared_bundle = None
 
     # Only launch background prewarm when there is real work to do (registry +
     # default bundle configured).  Otherwise mark bundles as ready immediately

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator
@@ -19,6 +20,36 @@ from amplifierd.state.event_bus import EventBus
 from amplifierd.state.session_manager import SessionManager
 
 logger = logging.getLogger(__name__)
+
+
+async def _prewarm(app: FastAPI) -> None:
+    """Background task: load default bundle, inject providers, prepare."""
+    try:
+        registry = app.state.bundle_registry
+        if not registry:
+            return
+        settings = app.state.settings
+        if not settings.default_bundle:
+            app.state.bundles_ready.set()
+            return
+
+        bundle = await registry.load(settings.default_bundle)
+
+        from amplifierd.providers import inject_providers, load_provider_config
+
+        providers = load_provider_config()
+        inject_providers(bundle, providers)
+
+        await bundle.prepare()
+
+        app.state.bundles_ready.set()
+        logger.info("Bundle pre-warmed and ready: %s", settings.default_bundle)
+    except asyncio.CancelledError:
+        logger.info("Bundle prewarm cancelled")
+        raise
+    except Exception as exc:
+        app.state.prewarm_error = str(exc)
+        logger.warning("Bundle prewarm failed: %s", exc, exc_info=True)
 
 
 @asynccontextmanager
@@ -112,18 +143,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 list(settings.bundles.keys()),
             )
 
-        # Pre-load the default bundle so first session creation is fast
-        if settings.default_bundle:
-            try:
-                await app.state.bundle_registry.load(settings.default_bundle)
-                logger.info("Pre-loaded default bundle: %s", settings.default_bundle)
-            except Exception:
-                logger.warning(
-                    "Failed to pre-load default bundle '%s'",
-                    settings.default_bundle,
-                    exc_info=True,
-                )
-
     except Exception:
         logger.warning("Failed to create BundleRegistry; starting without it", exc_info=True)
         app.state.bundle_registry = None
@@ -155,9 +174,27 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
         update_session_meta(app.state.daemon_session_path, {"plugins": plugin_names})
 
+    # Background state tracking for prewarm
+    app.state.bundles_ready = asyncio.Event()
+    app.state.prewarm_task = None
+    app.state.prewarm_error = None
+
+    # Start bundle loading in background — server yields immediately
+    prewarm_task = asyncio.create_task(_prewarm(app))
+    app.state.prewarm_task = prewarm_task
+    app.state.background_tasks.add(prewarm_task)
+    prewarm_task.add_done_callback(app.state.background_tasks.discard)
+
     yield
 
     # --- Shutdown ---
+    if app.state.prewarm_task and not app.state.prewarm_task.done():
+        app.state.prewarm_task.cancel()
+        try:
+            await app.state.prewarm_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
     if app.state.daemon_session_path:
         from datetime import UTC, datetime
 

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -50,7 +50,8 @@ async def _prewarm(app: FastAPI) -> None:
         # itself async (uses asyncio.gather internally), we give it a dedicated
         # event loop inside that thread via asyncio.run(). The main uvicorn loop
         # stays free and can respond to /ready, /health, etc. throughout.
-        await asyncio.to_thread(lambda: asyncio.run(bundle.prepare()))
+        prepared = await asyncio.to_thread(lambda: asyncio.run(bundle.prepare()))
+        app.state.prepared_bundle = prepared
 
         app.state.bundles_ready.set()
         logger.info("Bundle pre-warmed and ready: %s", settings.default_bundle)
@@ -188,6 +189,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     app.state.bundles_ready = asyncio.Event()
     app.state.prewarm_task = None
     app.state.prewarm_error = None
+    app.state.prepared_bundle = None
 
     # Only launch background prewarm when there is real work to do (registry +
     # default bundle configured).  Otherwise mark bundles as ready immediately

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -51,6 +51,20 @@ async def _prewarm(app: FastAPI) -> None:
         # event loop inside that thread via asyncio.run(). The main uvicorn loop
         # stays free and can respond to /ready, /health, etc. throughout.
         prepared = await asyncio.to_thread(lambda: asyncio.run(bundle.prepare()))
+
+        # Warm Python's sys.modules cache by creating (and discarding) a
+        # throwaway session.  create_session() -> session.initialize() imports
+        # every module package via importlib.  The first call is expensive
+        # (~12s); subsequent calls hit sys.modules and are fast (~1-2s).
+        # We pay the cost here in the background so the user's first real
+        # session is near-instant.
+        try:
+            _throwaway = await asyncio.to_thread(lambda: asyncio.run(prepared.create_session()))
+            del _throwaway
+            logger.info("Module import cache warmed via throwaway session")
+        except Exception:
+            logger.warning("Throwaway session failed (non-fatal)", exc_info=True)
+
         session_manager = getattr(app.state, "session_manager", None)
         if session_manager:
             session_manager.set_prepared_bundle(settings.default_bundle, prepared)
@@ -102,7 +116,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         import os as _os
         from pathlib import Path as _Path
 
-        _keys_path = _Path(_os.environ.get("AMPLIFIER_HOME", _Path.home() / ".amplifier")) / "keys.env"
+        _home = _Path(_os.environ.get("AMPLIFIER_HOME", _Path.home() / ".amplifier"))
+        _keys_path = _home / "keys.env"
         if _keys_path.is_file():
             _loaded = []
             for _line in _keys_path.read_text().splitlines():

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -41,7 +41,16 @@ async def _prewarm(app: FastAPI) -> None:
         providers = load_provider_config()
         inject_providers(bundle, providers)
 
-        await bundle.prepare()
+        # bundle.prepare() calls ModuleActivator._install_dependencies which uses
+        # synchronous subprocess.run() (uv pip install -e). Awaiting it directly
+        # on the main event loop freezes the entire server — no other coroutines
+        # (including GET /ready) can execute while uv is running.
+        #
+        # asyncio.to_thread() offloads to a worker thread. Because prepare() is
+        # itself async (uses asyncio.gather internally), we give it a dedicated
+        # event loop inside that thread via asyncio.run(). The main uvicorn loop
+        # stays free and can respond to /ready, /health, etc. throughout.
+        await asyncio.to_thread(lambda: asyncio.run(bundle.prepare()))
 
         app.state.bundles_ready.set()
         logger.info("Bundle pre-warmed and ready: %s", settings.default_bundle)

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -27,6 +27,7 @@ async def _prewarm(app: FastAPI) -> None:
     try:
         registry = app.state.bundle_registry
         if not registry:
+            app.state.bundles_ready.set()
             return
         settings = app.state.settings
         if not settings.default_bundle:
@@ -179,11 +180,16 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     app.state.prewarm_task = None
     app.state.prewarm_error = None
 
-    # Start bundle loading in background — server yields immediately
-    prewarm_task = asyncio.create_task(_prewarm(app))
-    app.state.prewarm_task = prewarm_task
-    app.state.background_tasks.add(prewarm_task)
-    prewarm_task.add_done_callback(app.state.background_tasks.discard)
+    # Only launch background prewarm when there is real work to do (registry +
+    # default bundle configured).  Otherwise mark bundles as ready immediately
+    # so that the 503 route guard does not block session creation.
+    if app.state.bundle_registry and settings.default_bundle:
+        prewarm_task = asyncio.create_task(_prewarm(app))
+        app.state.prewarm_task = prewarm_task
+        app.state.background_tasks.add(prewarm_task)
+        prewarm_task.add_done_callback(app.state.background_tasks.discard)
+    else:
+        app.state.bundles_ready.set()
 
     yield
 

--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -22,8 +22,11 @@ from amplifierd.state.session_manager import SessionManager
 logger = logging.getLogger(__name__)
 
 
-async def _prewarm(app: FastAPI) -> None:
-    """Background task: load default bundle, inject providers, prepare."""
+async def prewarm(app: FastAPI) -> None:
+    """Background task: load default bundle, inject providers, prepare.
+
+    Public API — imported by amplifierd.routes.health and distro_plugin.reload.
+    """
     try:
         registry = app.state.bundle_registry
         if not registry:
@@ -33,6 +36,8 @@ async def _prewarm(app: FastAPI) -> None:
         if not settings.default_bundle:
             app.state.bundles_ready.set()
             return
+
+        logger.info("Starting bundle prewarm for '%s'...", settings.default_bundle)
 
         bundle = await registry.load(settings.default_bundle)
 
@@ -50,17 +55,37 @@ async def _prewarm(app: FastAPI) -> None:
         # itself async (uses asyncio.gather internally), we give it a dedicated
         # event loop inside that thread via asyncio.run(). The main uvicorn loop
         # stays free and can respond to /ready, /health, etc. throughout.
-        prepared = await asyncio.to_thread(lambda: asyncio.run(bundle.prepare()))
-
-        # Warm Python's sys.modules cache by creating (and discarding) a
-        # throwaway session.  create_session() -> session.initialize() imports
-        # every module package via importlib.  The first call is expensive
-        # (~12s); subsequent calls hit sys.modules and are fast (~1-2s).
-        # We pay the cost here in the background so the user's first real
-        # session is near-instant.
+        #
+        # NOTE: asyncio.wait_for() + asyncio.to_thread() — the timeout cancels
+        # the awaiter but the worker thread keeps running. The thread running
+        # subprocess.run() (uv pip install) will complete on its own. A brief
+        # period of overlapping work is possible on retry, but uv uses file locks
+        # so this is safe. The user gets a clear timeout error immediately.
         try:
-            _throwaway = await asyncio.to_thread(lambda: asyncio.run(prepared.create_session()))
-            del _throwaway
+            prepared = await asyncio.wait_for(
+                asyncio.to_thread(lambda: asyncio.run(bundle.prepare())),
+                timeout=300,
+            )
+        except TimeoutError:
+            raise TimeoutError(
+                "Bundle preparation timed out after 300 seconds. "
+                "Check network connectivity and retry."
+            )
+
+        # Warm Python's sys.modules cache by creating (and immediately cleaning
+        # up) a throwaway session.  create_session() -> session.initialize()
+        # imports every module package via importlib.  The first call is
+        # expensive (~12s); subsequent calls hit sys.modules and are fast
+        # (~1-2s).  We pay the cost here in the background so the user's first
+        # real session is near-instant.
+        async def _warmup_imports() -> None:
+            """Create and immediately clean up a session to warm sys.modules."""
+            session = await prepared.create_session()
+            if hasattr(session, "cleanup"):
+                await session.cleanup()
+
+        try:
+            await asyncio.to_thread(lambda: asyncio.run(_warmup_imports()))
             logger.info("Module import cache warmed via throwaway session")
         except Exception:
             logger.warning("Throwaway session failed (non-fatal)", exc_info=True)
@@ -75,7 +100,12 @@ async def _prewarm(app: FastAPI) -> None:
         logger.info("Bundle prewarm cancelled")
         raise
     except Exception as exc:
+        # Set bundles_ready even on failure so the 503 guard releases.
+        # Users can still attempt session creation (which will fail with 502
+        # if the bundle is actually broken), access the wizard to fix config,
+        # or retry via POST /ready/retry.
         app.state.prewarm_error = str(exc)
+        app.state.bundles_ready.set()
         logger.warning("Bundle prewarm failed: %s", exc, exc_info=True)
 
 
@@ -211,7 +241,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # default bundle configured).  Otherwise mark bundles as ready immediately
     # so that the 503 route guard does not block session creation.
     if app.state.bundle_registry and settings.default_bundle:
-        prewarm_task = asyncio.create_task(_prewarm(app))
+        prewarm_task = asyncio.create_task(prewarm(app))
         app.state.prewarm_task = prewarm_task
         app.state.background_tasks.add(prewarm_task)
         prewarm_task.add_done_callback(app.state.background_tasks.discard)

--- a/src/amplifierd/routes/health.py
+++ b/src/amplifierd/routes/health.py
@@ -121,15 +121,29 @@ async def ready_retry(request: Request) -> dict:
         except (asyncio.CancelledError, Exception):
             pass
 
+    # Clear stale prepared bundle cache so the retry loads fresh
+    session_manager = getattr(app.state, "session_manager", None)
+    if session_manager and hasattr(session_manager, "clear_prepared_bundle"):
+        session_manager.clear_prepared_bundle()
+
+    # Invalidate registry cache so retry loads fresh from disk
+    registry = getattr(app.state, "bundle_registry", None)
+    settings = getattr(app.state, "settings", None)
+    if registry and settings and getattr(settings, "default_bundle", None):
+        try:
+            await registry.update(settings.default_bundle)
+        except Exception:
+            pass  # Best effort — prewarm will re-attempt load anyway
+
     # Clear ready event
     bundles_ready = getattr(app.state, "bundles_ready", None)
     if bundles_ready:
         bundles_ready.clear()
 
     # Start new prewarm task
-    from amplifierd.app import _prewarm
+    from amplifierd.app import prewarm
 
-    new_task = asyncio.create_task(_prewarm(app))
+    new_task = asyncio.create_task(prewarm(app))
     app.state.prewarm_task = new_task
     app.state.background_tasks.add(new_task)
     new_task.add_done_callback(app.state.background_tasks.discard)

--- a/src/amplifierd/routes/health.py
+++ b/src/amplifierd/routes/health.py
@@ -88,3 +88,50 @@ async def info() -> InfoResponse:
         capabilities=CAPABILITIES,
         module_types=MODULE_TYPES,
     )
+
+
+@health_router.get("/ready")
+async def ready(request: Request) -> dict:
+    """Return bundle readiness status for loading screen polling."""
+    bundles_ready = getattr(request.app.state, "bundles_ready", None)
+    prewarm_error = getattr(request.app.state, "prewarm_error", None)
+    is_ready = bundles_ready.is_set() if bundles_ready else True
+    result: dict = {"ready": is_ready}
+    if prewarm_error:
+        result["error"] = prewarm_error
+    return result
+
+
+@health_router.post("/ready/retry")
+async def ready_retry(request: Request) -> dict:
+    """Retry bundle prewarm after a failure."""
+    import asyncio
+
+    app = request.app
+
+    # Clear error state
+    app.state.prewarm_error = None
+
+    # Cancel existing task if any
+    old_task = getattr(app.state, "prewarm_task", None)
+    if old_task and not old_task.done():
+        old_task.cancel()
+        try:
+            await old_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    # Clear ready event
+    bundles_ready = getattr(app.state, "bundles_ready", None)
+    if bundles_ready:
+        bundles_ready.clear()
+
+    # Start new prewarm task
+    from amplifierd.app import _prewarm
+
+    new_task = asyncio.create_task(_prewarm(app))
+    app.state.prewarm_task = new_task
+    app.state.background_tasks.add(new_task)
+    new_task.add_done_callback(app.state.background_tasks.discard)
+
+    return {"status": "retrying"}

--- a/src/amplifierd/routes/sessions.py
+++ b/src/amplifierd/routes/sessions.py
@@ -130,23 +130,12 @@ async def create_session(request: Request, body: CreateSessionRequest) -> dict:
             detail="Bundles are still loading. Retry shortly.",
             headers={"Retry-After": "5"},
         )
-    # Use pre-warmed PreparedBundle if available and bundle matches the default.
-    # This skips the expensive load → inject_providers → prepare pipeline on
-    # first session creation after daemon startup (saves 10-20 seconds).
-    prepared_bundle = None
     settings: DaemonSettings = request.app.state.settings
-    if not body.bundle_uri and (
-        body.bundle_name == settings.default_bundle
-        or (not body.bundle_name and settings.default_bundle)
-    ):
-        prepared_bundle = getattr(request.app.state, "prepared_bundle", None)
-
     try:
         handle = await manager.create(
             bundle_name=body.bundle_name or settings.default_bundle,
             bundle_uri=body.bundle_uri,
             working_dir=body.working_dir,
-            prepared_bundle=prepared_bundle,
         )
     except ValueError as exc:
         logger.warning("Invalid session creation request: %s", exc)

--- a/src/amplifierd/routes/sessions.py
+++ b/src/amplifierd/routes/sessions.py
@@ -122,6 +122,14 @@ async def create_session(request: Request, body: CreateSessionRequest) -> dict:
                 status_code=400,
                 detail=detail.model_dump(exclude_none=True),
             )
+    # Block session creation while bundles are prewarming
+    bundles_ready = getattr(request.app.state, "bundles_ready", None)
+    if bundles_ready and not bundles_ready.is_set():
+        raise HTTPException(
+            status_code=503,
+            detail="Bundles are still loading. Retry shortly.",
+            headers={"Retry-After": "5"},
+        )
     try:
         handle = await manager.create(
             bundle_name=body.bundle_name,
@@ -184,9 +192,7 @@ async def get_session(request: Request, session_id: str) -> SessionDetail:
 
 
 @sessions_router.patch("/{session_id}")
-async def patch_session(
-    request: Request, session_id: str, body: PatchSessionRequest
-) -> dict:
+async def patch_session(request: Request, session_id: str, body: PatchSessionRequest) -> dict:
     """Patch session properties (working_dir, name).
 
     Works for both live (in-memory) and disk-only (history) sessions.
@@ -582,6 +588,14 @@ async def session_tree(request: Request, session_id: str) -> SessionTreeNode:
 async def resume_session(request: Request, session_id: str) -> dict:
     """Resume a session from disk after server restart."""
     manager: SessionManager = request.app.state.session_manager
+    # Block session resume while bundles are prewarming
+    bundles_ready = getattr(request.app.state, "bundles_ready", None)
+    if bundles_ready and not bundles_ready.is_set():
+        raise HTTPException(
+            status_code=503,
+            detail="Bundles are still loading. Retry shortly.",
+            headers={"Retry-After": "5"},
+        )
     try:
         handle = await manager.resume(session_id)
     except FileNotFoundError as exc:
@@ -682,9 +696,7 @@ async def set_mode(request: Request, session_id: str, body: SetModeRequest) -> d
         raise HTTPException(status_code=503, detail="Coordinator unavailable")
     state = getattr(coordinator, "session_state", None)
     if state is None:
-        raise HTTPException(
-            status_code=503, detail="Modes not available (hooks-mode not mounted)"
-        )
+        raise HTTPException(status_code=503, detail="Modes not available (hooks-mode not mounted)")
 
     discovery = state.get("mode_discovery")
     mode_hooks = state.get("mode_hooks")
@@ -700,7 +712,6 @@ async def set_mode(request: Request, session_id: str, body: SetModeRequest) -> d
         raise HTTPException(status_code=503, detail="Mode discovery not available")
     mode_def = discovery.find(body.mode_name)
     if not mode_def:
-        available = [n for n, _d, _s in discovery.list_modes()]
         detail = ProblemDetail(
             type=ErrorTypeURI.INVALID_REQUEST,
             title="Mode Not Found",

--- a/src/amplifierd/routes/sessions.py
+++ b/src/amplifierd/routes/sessions.py
@@ -130,11 +130,23 @@ async def create_session(request: Request, body: CreateSessionRequest) -> dict:
             detail="Bundles are still loading. Retry shortly.",
             headers={"Retry-After": "5"},
         )
+    # Use pre-warmed PreparedBundle if available and bundle matches the default.
+    # This skips the expensive load → inject_providers → prepare pipeline on
+    # first session creation after daemon startup (saves 10-20 seconds).
+    prepared_bundle = None
+    settings: DaemonSettings = request.app.state.settings
+    if not body.bundle_uri and (
+        body.bundle_name == settings.default_bundle
+        or (not body.bundle_name and settings.default_bundle)
+    ):
+        prepared_bundle = getattr(request.app.state, "prepared_bundle", None)
+
     try:
         handle = await manager.create(
-            bundle_name=body.bundle_name,
+            bundle_name=body.bundle_name or settings.default_bundle,
             bundle_uri=body.bundle_uri,
             working_dir=body.working_dir,
+            prepared_bundle=prepared_bundle,
         )
     except ValueError as exc:
         logger.warning("Invalid session creation request: %s", exc)

--- a/src/amplifierd/state/session_manager.py
+++ b/src/amplifierd/state/session_manager.py
@@ -215,6 +215,7 @@ class SessionManager:
         bundle_name: str | None = None,
         bundle_uri: str | None = None,
         working_dir: str | None = None,
+        prepared_bundle: Any | None = None,
     ) -> SessionHandle:
         """Create a new session by loading and preparing a bundle.
 
@@ -222,31 +223,41 @@ class SessionManager:
             bundle_name: Registered bundle name to load.
             bundle_uri: Bundle URI to load directly.
             working_dir: Working directory override; falls back to daemon config or home.
+            prepared_bundle: Pre-warmed PreparedBundle to reuse. When provided, the
+                entire load → inject_providers → prepare pipeline is skipped, making
+                session creation nearly instant (create_session() is still called).
 
         Returns:
             The newly created and registered SessionHandle.
 
         Raises:
-            RuntimeError: If BundleRegistry is not available.
-            ValueError: If neither bundle_name nor bundle_uri is provided.
+            RuntimeError: If BundleRegistry is not available (slow path only).
+            ValueError: If none of bundle_name, bundle_uri, or prepared_bundle provided.
         """
-        if not self._bundle_registry:
+        if not self._bundle_registry and prepared_bundle is None:
             raise RuntimeError("BundleRegistry not available")
-        if not bundle_name and not bundle_uri:
-            raise ValueError("bundle_name or bundle_uri required")
+        if not bundle_name and not bundle_uri and prepared_bundle is None:
+            raise ValueError("bundle_name, bundle_uri, or prepared_bundle required")
 
         wd = self.resolve_working_dir(working_dir)
-        name_or_uri = bundle_uri or bundle_name
-        bundle = await self._bundle_registry.load(name_or_uri)
 
-        # Inject providers from ~/.amplifier/settings.yaml BEFORE prepare()
-        # so the activation step downloads and installs their dependencies.
-        from amplifierd.providers import inject_providers, load_provider_config
+        if prepared_bundle is not None:
+            # Fast path: reuse pre-warmed PreparedBundle — skip load + inject + prepare
+            prepared = prepared_bundle
+        else:
+            # Slow path: full load + inject_providers + prepare pipeline
+            name_or_uri = bundle_uri or bundle_name
+            bundle = await self._bundle_registry.load(name_or_uri)
 
-        providers = load_provider_config()
-        inject_providers(bundle, providers)
+            # Inject providers from ~/.amplifier/settings.yaml BEFORE prepare()
+            # so the activation step downloads and installs their dependencies.
+            from amplifierd.providers import inject_providers, load_provider_config
 
-        prepared = await bundle.prepare()
+            providers = load_provider_config()
+            inject_providers(bundle, providers)
+
+            prepared = await bundle.prepare()
+
         session = await prepared.create_session(session_cwd=Path(wd))
 
         # Register transcript/metadata persistence hooks

--- a/src/amplifierd/state/session_manager.py
+++ b/src/amplifierd/state/session_manager.py
@@ -44,6 +44,7 @@ class SessionManager:
         self._bundle_registry = bundle_registry
         # Prefer the explicit projects_dir; fall back to the legacy alias.
         self._projects_dir: Path | None = projects_dir or sessions_dir
+        self._prepared_bundles: dict[str, Any] = {}  # bundle_name -> PreparedBundle
         self._index: SessionIndex | None = None
         if self._projects_dir:
             index_path = self._projects_dir / "index.json"
@@ -54,6 +55,17 @@ class SessionManager:
                     self._index = SessionIndex.rebuild(self._projects_dir)
             else:
                 self._index = SessionIndex.rebuild(self._projects_dir)
+
+    def set_prepared_bundle(self, bundle_name: str, prepared: Any) -> None:
+        """Cache a pre-warmed PreparedBundle for instant session creation."""
+        self._prepared_bundles[bundle_name] = prepared
+
+    def clear_prepared_bundle(self, bundle_name: str | None = None) -> None:
+        """Clear cached PreparedBundle(s). Called on reload."""
+        if bundle_name:
+            self._prepared_bundles.pop(bundle_name, None)
+        else:
+            self._prepared_bundles.clear()
 
     @property
     def event_bus(self) -> EventBus:
@@ -215,7 +227,6 @@ class SessionManager:
         bundle_name: str | None = None,
         bundle_uri: str | None = None,
         working_dir: str | None = None,
-        prepared_bundle: Any | None = None,
     ) -> SessionHandle:
         """Create a new session by loading and preparing a bundle.
 
@@ -223,28 +234,26 @@ class SessionManager:
             bundle_name: Registered bundle name to load.
             bundle_uri: Bundle URI to load directly.
             working_dir: Working directory override; falls back to daemon config or home.
-            prepared_bundle: Pre-warmed PreparedBundle to reuse. When provided, the
-                entire load → inject_providers → prepare pipeline is skipped, making
-                session creation nearly instant (create_session() is still called).
 
         Returns:
             The newly created and registered SessionHandle.
 
         Raises:
-            RuntimeError: If BundleRegistry is not available (slow path only).
-            ValueError: If none of bundle_name, bundle_uri, or prepared_bundle provided.
+            RuntimeError: If BundleRegistry is not available.
+            ValueError: If neither bundle_name nor bundle_uri is provided.
         """
-        if not self._bundle_registry and prepared_bundle is None:
+        if not self._bundle_registry:
             raise RuntimeError("BundleRegistry not available")
-        if not bundle_name and not bundle_uri and prepared_bundle is None:
-            raise ValueError("bundle_name, bundle_uri, or prepared_bundle required")
+        if not bundle_name and not bundle_uri:
+            raise ValueError("bundle_name or bundle_uri required")
 
         wd = self.resolve_working_dir(working_dir)
 
-        if prepared_bundle is not None:
-            # Fast path: reuse pre-warmed PreparedBundle — skip load + inject + prepare
-            prepared = prepared_bundle
-        else:
+        # Fast path: use pre-warmed PreparedBundle if available
+        cache_key = bundle_name or bundle_uri
+        prepared = self._prepared_bundles.get(cache_key) if cache_key else None
+
+        if prepared is None:
             # Slow path: full load + inject_providers + prepare pipeline
             name_or_uri = bundle_uri or bundle_name
             bundle = await self._bundle_registry.load(name_or_uri)
@@ -378,25 +387,29 @@ class SessionManager:
         working_dir = metadata.get("working_dir", str(Path.home()))
 
         # 4. Load bundle, inject providers, prepare, create session
-        fallback = self._settings.default_bundle or "distro"
-        try:
-            bundle = await self._bundle_registry.load(bundle_name)
-        except Exception:
-            if bundle_name == fallback:
-                raise
-            logger.warning(
-                "Bundle %r not available, falling back to %r",
-                bundle_name,
-                fallback,
-            )
-            bundle = await self._bundle_registry.load(fallback)
+        # Fast path: use pre-warmed PreparedBundle if available
+        prepared = self._prepared_bundles.get(bundle_name)
+        if prepared is None:
+            fallback = self._settings.default_bundle or "distro"
+            try:
+                bundle = await self._bundle_registry.load(bundle_name)
+            except Exception:
+                if bundle_name == fallback:
+                    raise
+                logger.warning(
+                    "Bundle %r not available, falling back to %r",
+                    bundle_name,
+                    fallback,
+                )
+                bundle = await self._bundle_registry.load(fallback)
 
-        from amplifierd.providers import inject_providers, load_provider_config
+            from amplifierd.providers import inject_providers, load_provider_config
 
-        providers = load_provider_config()
-        inject_providers(bundle, providers)
+            providers = load_provider_config()
+            inject_providers(bundle, providers)
 
-        prepared = await bundle.prepare()
+            prepared = await bundle.prepare()
+
         session = await prepared.create_session(
             session_id=session_id,
             is_resumed=True,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -140,6 +140,69 @@ async def test_prewarm_error_stored_in_app_state() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_prewarm_stores_prepared_bundle_on_app_state() -> None:
+    """_prewarm stores the PreparedBundle result on app.state.prepared_bundle.
+
+    After prewarm completes, app.state.prepared_bundle should hold the
+    PreparedBundle returned by bundle.prepare() so subsequent session
+    creation can reuse it instead of calling prepare() again.
+    """
+    fake_prepared = MagicMock(name="fake_prepared_bundle")
+    fake_prepared.create_session = AsyncMock()
+
+    async def instant_load(source: str) -> SimpleNamespace:
+        bundle = _make_fake_bundle()
+        bundle.prepare = AsyncMock(return_value=fake_prepared)
+        return bundle
+
+    mock_registry = MagicMock()
+    mock_registry.load = instant_load
+    mock_registry.register = MagicMock()
+
+    settings = DaemonSettings(default_bundle="test-bundle")
+    app = create_app(settings=settings)
+
+    with patch("amplifier_foundation.BundleRegistry", return_value=mock_registry):
+        async with asyncio.timeout(5.0):
+            async with app.router.lifespan_context(app):
+                await asyncio.wait_for(app.state.bundles_ready.wait(), timeout=3.0)
+
+                assert app.state.prepared_bundle is fake_prepared, (
+                    "app.state.prepared_bundle should be the PreparedBundle returned by prepare()"
+                )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prepared_bundle_initialized_to_none_in_lifespan() -> None:
+    """app.state.prepared_bundle is initialized to None at lifespan startup.
+
+    Before prewarm has a chance to set it, it should be None (not missing).
+    """
+    load_gate: asyncio.Event = asyncio.Event()
+
+    async def blocking_load(source: str) -> SimpleNamespace:
+        await load_gate.wait()
+        return _make_fake_bundle()
+
+    mock_registry = MagicMock()
+    mock_registry.load = blocking_load
+    mock_registry.register = MagicMock()
+
+    settings = DaemonSettings(default_bundle="test-bundle")
+    app = create_app(settings=settings)
+
+    with patch("amplifier_foundation.BundleRegistry", return_value=mock_registry):
+        async with asyncio.timeout(5.0):
+            async with app.router.lifespan_context(app):
+                # Before prewarm completes, prepared_bundle should be None
+                assert app.state.prepared_bundle is None
+
+                load_gate.set()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_prewarm_skipped_when_no_default_bundle() -> None:
     """When no default_bundle is configured bundles_ready is set immediately."""
     mock_registry = MagicMock()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,160 @@
+"""Tests for app.py lifespan behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from amplifierd.app import create_app
+from amplifierd.config import DaemonSettings
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_bundle() -> SimpleNamespace:
+    """Minimal bundle stub that satisfies _prewarm."""
+    return SimpleNamespace(
+        name="test-bundle",
+        providers=[],
+        prepare=AsyncMock(return_value=None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_server_accepts_connections_before_bundle_load() -> None:
+    """Server should respond to /health while bundle is still loading.
+
+    With the old lifespan the startup blocked at ``await registry.load()``
+    before yielding, so the HTTP server never became reachable until the
+    load finished.  After the restructure the lifespan yields immediately
+    and load runs in a background task, so /health is immediately reachable.
+    """
+    load_started: asyncio.Event = asyncio.Event()
+    load_gate: asyncio.Event = asyncio.Event()
+
+    async def blocking_load(source: str) -> SimpleNamespace:
+        load_started.set()
+        await load_gate.wait()
+        return _make_fake_bundle()
+
+    mock_registry = MagicMock()
+    mock_registry.load = blocking_load
+    mock_registry.register = MagicMock()
+
+    settings = DaemonSettings(default_bundle="test-bundle")
+    app = create_app(settings=settings)
+
+    with patch("amplifier_foundation.BundleRegistry", return_value=mock_registry):
+        # The whole interaction must complete within 5 s.
+        # With the OLD lifespan (blocking load before yield) the lifespan
+        # context manager would block indefinitely and we'd never enter the
+        # body — causing the outer timeout to fire.
+        async with asyncio.timeout(5.0):
+            async with app.router.lifespan_context(app):
+                # Prewarm must have started before we check health — proves
+                # load is running in the background, not in the startup path.
+                await asyncio.wait_for(load_started.wait(), timeout=2.0)
+
+                async with httpx.AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/health")
+                    assert resp.status_code == 200
+
+                # Let _prewarm finish so the app shuts down cleanly.
+                load_gate.set()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bundles_ready_event_set_after_successful_prewarm() -> None:
+    """app.state.bundles_ready is set once _prewarm completes successfully."""
+
+    async def instant_load(source: str) -> SimpleNamespace:
+        return _make_fake_bundle()
+
+    mock_registry = MagicMock()
+    mock_registry.load = instant_load
+    mock_registry.register = MagicMock()
+
+    settings = DaemonSettings(default_bundle="test-bundle")
+    app = create_app(settings=settings)
+
+    with patch("amplifier_foundation.BundleRegistry", return_value=mock_registry):
+        async with asyncio.timeout(5.0):
+            async with app.router.lifespan_context(app):
+                await asyncio.wait_for(app.state.bundles_ready.wait(), timeout=3.0)
+
+                async with httpx.AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/health")
+                    assert resp.status_code == 200
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prewarm_error_stored_in_app_state() -> None:
+    """When _prewarm fails the error message is stored in app.state.prewarm_error."""
+
+    async def failing_load(source: str) -> None:
+        raise RuntimeError("registry exploded")
+
+    mock_registry = MagicMock()
+    mock_registry.load = failing_load
+    mock_registry.register = MagicMock()
+
+    settings = DaemonSettings(default_bundle="test-bundle")
+    app = create_app(settings=settings)
+
+    with patch("amplifier_foundation.BundleRegistry", return_value=mock_registry):
+        async with asyncio.timeout(5.0):
+            async with app.router.lifespan_context(app):
+                # Give the background task a moment to fail.
+                await asyncio.sleep(0.1)
+
+                async with httpx.AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    # Server still healthy even when prewarm fails.
+                    resp = await client.get("/health")
+                    assert resp.status_code == 200
+
+                # Error captured on app.state.
+                assert app.state.prewarm_error is not None
+                assert "registry exploded" in app.state.prewarm_error
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prewarm_skipped_when_no_default_bundle() -> None:
+    """When no default_bundle is configured bundles_ready is set immediately."""
+    mock_registry = MagicMock()
+    mock_registry.register = MagicMock()
+
+    settings = DaemonSettings(default_bundle=None)  # explicitly no default bundle
+    app = create_app(settings=settings)
+
+    with patch("amplifier_foundation.BundleRegistry", return_value=mock_registry):
+        async with asyncio.timeout(5.0):
+            async with app.router.lifespan_context(app):
+                await asyncio.wait_for(app.state.bundles_ready.wait(), timeout=2.0)
+
+                async with httpx.AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/health")
+                    assert resp.status_code == 200

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -140,11 +140,11 @@ async def test_prewarm_error_stored_in_app_state() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_prewarm_stores_prepared_bundle_on_app_state() -> None:
-    """_prewarm stores the PreparedBundle result on app.state.prepared_bundle.
+async def test_prewarm_stores_prepared_bundle_on_session_manager() -> None:
+    """_prewarm stores the PreparedBundle result on session_manager._prepared_bundles.
 
-    After prewarm completes, app.state.prepared_bundle should hold the
-    PreparedBundle returned by bundle.prepare() so subsequent session
+    After prewarm completes, session_manager._prepared_bundles[default_bundle] should
+    hold the PreparedBundle returned by bundle.prepare() so subsequent session
     creation can reuse it instead of calling prepare() again.
     """
     fake_prepared = MagicMock(name="fake_prepared_bundle")
@@ -167,17 +167,19 @@ async def test_prewarm_stores_prepared_bundle_on_app_state() -> None:
             async with app.router.lifespan_context(app):
                 await asyncio.wait_for(app.state.bundles_ready.wait(), timeout=3.0)
 
-                assert app.state.prepared_bundle is fake_prepared, (
-                    "app.state.prepared_bundle should be the PreparedBundle returned by prepare()"
+                cached = app.state.session_manager._prepared_bundles.get("test-bundle")  # noqa: SLF001
+                assert cached is fake_prepared, (
+                    "session_manager._prepared_bundles['test-bundle'] should be the "
+                    "PreparedBundle returned by prepare()"
                 )
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_prepared_bundle_initialized_to_none_in_lifespan() -> None:
-    """app.state.prepared_bundle is initialized to None at lifespan startup.
+async def test_prepared_bundle_cache_empty_before_prewarm() -> None:
+    """session_manager._prepared_bundles is empty at lifespan startup.
 
-    Before prewarm has a chance to set it, it should be None (not missing).
+    Before prewarm has a chance to populate it, the cache should be empty.
     """
     load_gate: asyncio.Event = asyncio.Event()
 
@@ -195,8 +197,8 @@ async def test_prepared_bundle_initialized_to_none_in_lifespan() -> None:
     with patch("amplifier_foundation.BundleRegistry", return_value=mock_registry):
         async with asyncio.timeout(5.0):
             async with app.router.lifespan_context(app):
-                # Before prewarm completes, prepared_bundle should be None
-                assert app.state.prepared_bundle is None
+                # Before prewarm completes, cache should be empty
+                assert app.state.session_manager._prepared_bundles == {}  # noqa: SLF001
 
                 load_gate.set()
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -13,6 +18,44 @@ def client() -> TestClient:
     """Create a test client from the app factory."""
     app = create_app()
     return TestClient(app)
+
+
+def _make_fake_session(session_id: str = "fake-session-1") -> SimpleNamespace:
+    """Create a minimal fake AmplifierSession for session creation tests."""
+    fake_coordinator = SimpleNamespace(
+        request_cancel=lambda immediate: None,
+        hooks=MagicMock(),
+    )
+    return SimpleNamespace(
+        session_id=session_id,
+        parent_id=None,
+        coordinator=fake_coordinator,
+        cleanup=AsyncMock(),
+        execute=AsyncMock(return_value="ok"),
+    )
+
+
+def _make_mock_registry(session_id: str = "fake-session-1") -> MagicMock:
+    """Create a mock BundleRegistry that returns fake sessions."""
+    fake_session = _make_fake_session(session_id)
+    mock_prepared = MagicMock()
+    mock_prepared.create_session = AsyncMock(return_value=fake_session)
+    mock_bundle = MagicMock()
+    mock_bundle.prepare = AsyncMock(return_value=mock_prepared)
+    mock_registry = MagicMock()
+    mock_registry.load = AsyncMock(return_value=mock_bundle)
+    return mock_registry
+
+
+@pytest.fixture()
+def session_client() -> Generator[TestClient]:
+    """Test client with lifespan + mocked bundle registry for session creation."""
+    app = create_app()
+    with TestClient(app) as c:
+        mock_registry = _make_mock_registry()
+        c.app.state.bundle_registry = mock_registry  # type: ignore[union-attr]
+        c.app.state.session_manager._bundle_registry = mock_registry  # type: ignore[union-attr]  # noqa: SLF001
+        yield c
 
 
 @pytest.mark.unit
@@ -127,3 +170,56 @@ class TestOpenAPIEndpoint:
         """GET /redoc returns 200."""
         resp = client.get("/redoc")
         assert resp.status_code == 200
+
+
+@pytest.mark.unit
+class TestReadyEndpoint:
+    """Tests for GET /ready."""
+
+    def test_ready_returns_false_during_prewarm(self, client: TestClient) -> None:
+        """GET /ready returns {ready: false} when bundles_ready event is unset."""
+        client.app.state.bundles_ready = asyncio.Event()  # unset = still loading
+        resp = client.get("/ready")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ready"] is False
+
+    def test_ready_returns_true_after_prewarm(self, client: TestClient) -> None:
+        """GET /ready returns {ready: true} when bundles_ready event is set."""
+        event = asyncio.Event()
+        event.set()
+        client.app.state.bundles_ready = event
+        resp = client.get("/ready")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ready"] is True
+
+    def test_ready_returns_error_on_failure(self, client: TestClient) -> None:
+        """GET /ready includes error field when prewarm_error is set."""
+        client.app.state.bundles_ready = asyncio.Event()  # unset = failed, not ready
+        client.app.state.prewarm_error = "Bundle load failed: connection timeout"
+        resp = client.get("/ready")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ready"] is False
+        assert data["error"] == "Bundle load failed: connection timeout"
+
+
+@pytest.mark.unit
+class TestPrewarmGuard503:
+    """Tests for 503 guard on session creation/resume during prewarm."""
+
+    def test_session_creation_returns_503_during_prewarm(self, session_client: TestClient) -> None:
+        """POST /sessions returns 503 with Retry-After when bundles are still loading."""
+        session_client.app.state.bundles_ready = asyncio.Event()  # unset = loading
+        resp = session_client.post("/sessions", json={"bundle_name": "test-bundle"})
+        assert resp.status_code == 503
+        assert "Retry-After" in resp.headers
+
+    def test_session_creation_works_after_prewarm(self, session_client: TestClient) -> None:
+        """POST /sessions proceeds normally when bundles_ready event is set."""
+        event = asyncio.Event()
+        event.set()
+        session_client.app.state.bundles_ready = event
+        resp = session_client.post("/sessions", json={"bundle_name": "test-bundle"})
+        assert resp.status_code == 201

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -223,3 +223,39 @@ class TestPrewarmGuard503:
         session_client.app.state.bundles_ready = event
         resp = session_client.post("/sessions", json={"bundle_name": "test-bundle"})
         assert resp.status_code == 201
+
+
+@pytest.mark.unit
+class TestPrewarmFunction:
+    """Tests for the prewarm() background task (public API)."""
+
+    async def test_prewarm_failure_releases_bundles_ready(self) -> None:
+        """prewarm() sets bundles_ready even when bundle loading fails.
+
+        Without this, the 503 guard permanently blocks ALL session creation
+        after a prewarm failure. Users should still be able to reach the
+        wizard or retry via POST /ready/retry.
+        """
+        from fastapi import FastAPI
+
+        from amplifierd.app import prewarm  # public name after rename
+
+        app = FastAPI()
+        app.state.bundles_ready = asyncio.Event()
+        app.state.prewarm_error = None
+
+        mock_registry = MagicMock()
+        mock_registry.load = AsyncMock(side_effect=RuntimeError("Network failure"))
+        app.state.bundle_registry = mock_registry
+
+        app.state.settings = SimpleNamespace(default_bundle="my-bundle")
+
+        await prewarm(app)
+
+        # The 503 guard MUST release even after failure
+        assert app.state.bundles_ready.is_set(), (
+            "bundles_ready must be set after prewarm failure "
+            "to prevent the 503 guard permanently blocking session creation"
+        )
+        # Error must be captured so GET /ready can surface it
+        assert app.state.prewarm_error == "Network failure"

--- a/tests/test_session_creation.py
+++ b/tests/test_session_creation.py
@@ -122,19 +122,19 @@ class TestCreateSessionEndpoint:
     def test_create_session_uses_prewarmed_bundle_skips_registry_load(
         self, client: TestClient
     ) -> None:
-        """POST /sessions skips registry.load() when app.state.prepared_bundle is available.
+        """POST /sessions skips registry.load() when session_manager cache is populated.
 
-        When app.state.prepared_bundle is set and the request uses the default bundle,
-        the route should pass prepared_bundle to manager.create() which skips
-        the expensive registry.load() + bundle.prepare() pipeline.
+        When session_manager has a cached PreparedBundle for the default bundle,
+        manager.create() should skip the expensive registry.load() + bundle.prepare() pipeline.
         """
         # Build a fake prepared bundle that creates a new session
         fake_session = _make_fake_session("prewarmed-session-1")
         mock_prepared = MagicMock()
         mock_prepared.create_session = AsyncMock(return_value=fake_session)
 
-        # Place it on app.state as if prewarm already ran
-        client.app.state.prepared_bundle = mock_prepared  # type: ignore[union-attr]
+        # Place it in the session_manager cache as if prewarm already ran
+        session_manager = client.app.state.session_manager  # type: ignore[union-attr]
+        session_manager.set_prepared_bundle("distro", mock_prepared)
 
         # Reset the registry's load call count
         mock_registry = client.app.state.bundle_registry  # type: ignore[union-attr]

--- a/tests/test_session_creation.py
+++ b/tests/test_session_creation.py
@@ -52,6 +52,8 @@ def client() -> Generator[TestClient]:
         mock_registry = _make_mock_registry()
         c.app.state.bundle_registry = mock_registry  # type: ignore[union-attr]
         c.app.state.session_manager._bundle_registry = mock_registry  # type: ignore[union-attr]  # noqa: SLF001
+        # Mark bundles as ready so the 503 prewarm guard does not block tests
+        c.app.state.bundles_ready.set()  # type: ignore[union-attr]
         yield c
 
 

--- a/tests/test_session_creation.py
+++ b/tests/test_session_creation.py
@@ -118,3 +118,31 @@ class TestCreateSessionEndpoint:
         client.app.state.settings.default_bundle = None  # type: ignore[union-attr]
         resp = client.post("/sessions", json={})
         assert resp.status_code == 400
+
+    def test_create_session_uses_prewarmed_bundle_skips_registry_load(
+        self, client: TestClient
+    ) -> None:
+        """POST /sessions skips registry.load() when app.state.prepared_bundle is available.
+
+        When app.state.prepared_bundle is set and the request uses the default bundle,
+        the route should pass prepared_bundle to manager.create() which skips
+        the expensive registry.load() + bundle.prepare() pipeline.
+        """
+        # Build a fake prepared bundle that creates a new session
+        fake_session = _make_fake_session("prewarmed-session-1")
+        mock_prepared = MagicMock()
+        mock_prepared.create_session = AsyncMock(return_value=fake_session)
+
+        # Place it on app.state as if prewarm already ran
+        client.app.state.prepared_bundle = mock_prepared  # type: ignore[union-attr]
+
+        # Reset the registry's load call count
+        mock_registry = client.app.state.bundle_registry  # type: ignore[union-attr]
+        mock_registry.load.reset_mock()
+
+        # POST with no bundle → should use default bundle → should use prewarmed bundle
+        resp = client.post("/sessions", json={})
+        assert resp.status_code == 201
+
+        # registry.load() must NOT have been called — we took the fast path
+        mock_registry.load.assert_not_called()

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -172,8 +172,8 @@ class TestResumePassesSessionCwd:
         assert call_kwargs["is_resumed"] is True
 
 
-class TestSessionManagerCreateWithPreparedBundle:
-    """Tests for the fast-path prepared_bundle kwarg in SessionManager.create()."""
+class TestSessionManagerPreparedBundleCache:
+    """Tests for the internal _prepared_bundles cache in SessionManager."""
 
     @pytest.fixture
     def manager_with_registry(self) -> SessionManager:
@@ -185,41 +185,63 @@ class TestSessionManagerCreateWithPreparedBundle:
             bundle_registry=mock_registry,
         )
 
-    async def test_create_with_prepared_bundle_skips_registry_load(
+    async def test_create_uses_cached_prepared_bundle(
         self, manager_with_registry: SessionManager
     ) -> None:
-        """create() with prepared_bundle skips registry.load() entirely."""
+        """create() uses _prepared_bundles cache and skips registry.load()."""
         fake_session = MagicMock()
-        fake_session.session_id = "fast-session-1"
+        fake_session.session_id = "cached-session-1"
         fake_session.parent_id = None
 
         mock_prepared = MagicMock()
         mock_prepared.create_session = AsyncMock(return_value=fake_session)
 
-        handle = await manager_with_registry.create(prepared_bundle=mock_prepared)
+        manager_with_registry.set_prepared_bundle("distro", mock_prepared)
+        handle = await manager_with_registry.create(bundle_name="distro")
 
-        # registry.load() must NOT be called — we skipped the slow path
+        # registry.load() must NOT be called — we used the internal cache
         manager_with_registry._bundle_registry.load.assert_not_called()  # noqa: SLF001
-        assert handle.session_id == "fast-session-1"
+        assert handle.session_id == "cached-session-1"
 
-    async def test_create_with_prepared_bundle_calls_create_session(
+    async def test_create_falls_through_without_cache(
         self, manager_with_registry: SessionManager
     ) -> None:
-        """create() with prepared_bundle calls create_session() on the PreparedBundle."""
+        """create() uses the slow path when no cached bundle exists."""
         fake_session = MagicMock()
-        fake_session.session_id = "fast-session-2"
+        fake_session.session_id = "slow-session-1"
         fake_session.parent_id = None
 
         mock_prepared = MagicMock()
         mock_prepared.create_session = AsyncMock(return_value=fake_session)
+        mock_bundle = MagicMock()
+        mock_bundle.prepare = AsyncMock(return_value=mock_prepared)
+        manager_with_registry._bundle_registry.load = AsyncMock(return_value=mock_bundle)  # noqa: SLF001
 
-        await manager_with_registry.create(prepared_bundle=mock_prepared)
+        handle = await manager_with_registry.create(bundle_name="slow-bundle")
 
-        mock_prepared.create_session.assert_awaited_once()
+        # registry.load() must be called — no cache available
+        manager_with_registry._bundle_registry.load.assert_called_once()  # noqa: SLF001
+        assert handle.session_id == "slow-session-1"
 
-    async def test_create_without_bundle_info_raises_mentioning_prepared_bundle(
+    def test_set_and_clear_prepared_bundle(self, manager_with_registry: SessionManager) -> None:
+        """set_prepared_bundle stores a bundle; clear_prepared_bundle removes it."""
+        mock_prepared = MagicMock()
+        manager_with_registry.set_prepared_bundle("distro", mock_prepared)
+        assert manager_with_registry._prepared_bundles.get("distro") is mock_prepared  # noqa: SLF001
+
+        manager_with_registry.clear_prepared_bundle("distro")
+        assert "distro" not in manager_with_registry._prepared_bundles  # noqa: SLF001
+
+    def test_clear_all_prepared_bundles(self, manager_with_registry: SessionManager) -> None:
+        """clear_prepared_bundle() with no args clears all cached bundles."""
+        manager_with_registry.set_prepared_bundle("a", MagicMock())
+        manager_with_registry.set_prepared_bundle("b", MagicMock())
+        manager_with_registry.clear_prepared_bundle()
+        assert manager_with_registry._prepared_bundles == {}  # noqa: SLF001
+
+    async def test_create_without_bundle_raises(
         self, manager_with_registry: SessionManager
     ) -> None:
-        """create() error message mentions prepared_bundle as a third option."""
-        with pytest.raises(ValueError, match="prepared_bundle"):
+        """create() with no bundle_name or bundle_uri raises ValueError."""
+        with pytest.raises(ValueError, match="bundle_name or bundle_uri required"):
             await manager_with_registry.create()

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -170,3 +170,56 @@ class TestResumePassesSessionCwd:
         assert call_kwargs["session_cwd"] == Path(working_dir)
         assert call_kwargs["session_id"] == session_id
         assert call_kwargs["is_resumed"] is True
+
+
+class TestSessionManagerCreateWithPreparedBundle:
+    """Tests for the fast-path prepared_bundle kwarg in SessionManager.create()."""
+
+    @pytest.fixture
+    def manager_with_registry(self) -> SessionManager:
+        mock_registry = MagicMock()
+        mock_registry.load = AsyncMock()
+        return SessionManager(
+            event_bus=EventBus(),
+            settings=DaemonSettings(),
+            bundle_registry=mock_registry,
+        )
+
+    async def test_create_with_prepared_bundle_skips_registry_load(
+        self, manager_with_registry: SessionManager
+    ) -> None:
+        """create() with prepared_bundle skips registry.load() entirely."""
+        fake_session = MagicMock()
+        fake_session.session_id = "fast-session-1"
+        fake_session.parent_id = None
+
+        mock_prepared = MagicMock()
+        mock_prepared.create_session = AsyncMock(return_value=fake_session)
+
+        handle = await manager_with_registry.create(prepared_bundle=mock_prepared)
+
+        # registry.load() must NOT be called — we skipped the slow path
+        manager_with_registry._bundle_registry.load.assert_not_called()  # noqa: SLF001
+        assert handle.session_id == "fast-session-1"
+
+    async def test_create_with_prepared_bundle_calls_create_session(
+        self, manager_with_registry: SessionManager
+    ) -> None:
+        """create() with prepared_bundle calls create_session() on the PreparedBundle."""
+        fake_session = MagicMock()
+        fake_session.session_id = "fast-session-2"
+        fake_session.parent_id = None
+
+        mock_prepared = MagicMock()
+        mock_prepared.create_session = AsyncMock(return_value=fake_session)
+
+        await manager_with_registry.create(prepared_bundle=mock_prepared)
+
+        mock_prepared.create_session.assert_awaited_once()
+
+    async def test_create_without_bundle_info_raises_mentioning_prepared_bundle(
+        self, manager_with_registry: SessionManager
+    ) -> None:
+        """create() error message mentions prepared_bundle as a third option."""
+        with pytest.raises(ValueError, match="prepared_bundle"):
+            await manager_with_registry.create()


### PR DESCRIPTION
## Summary

Eliminate 30+ second cold-start by prewarming the bundle at server startup as a background task. Server accepts connections immediately, shows readiness state via /ready endpoint, and caches the PreparedBundle for instant session creation.

## Changes

### Lifespan restructure (app.py)
- Move SessionManager creation and plugin discovery before `yield` so the server accepts HTTP connections immediately
- Bundle loading runs as a background `asyncio.Task` (`prewarm()`)
- `bundle.prepare()` offloaded to thread pool via `asyncio.to_thread()` to avoid blocking the event loop (it uses synchronous `subprocess.run` internally)
- Throwaway session created during prewarm to warm Python's `sys.modules` cache — subsequent session creation skips expensive `importlib.import_module()` calls
- 5-minute timeout on prewarm prevents infinite loading state
- Prewarm failure releases the 503 guard (sets `bundles_ready`) so users can access the wizard or retry
- Restores `keys.env` loading that was dropped during restructure

### Readiness endpoint (health.py)
- `GET /ready`: Returns `{ready: bool, error: str | null}` for loading screen polling
- `POST /ready/retry`: Restarts prewarm with full cache invalidation (clears prepared bundles + registry cache)

### Session creation (session_manager.py)
- `PreparedBundle` cache via `set_prepared_bundle()` / `clear_prepared_bundle()` — all callers benefit (sessions.py routes, chat plugin, any future plugin)
- `create()` and `resume()` check internal cache before running the slow load+inject+prepare pipeline

### Route guard (sessions.py)
- `POST /sessions` and `POST /sessions/{id}/resume` return 503 with `Retry-After: 5` during prewarm to prevent concurrent `prepare()` subprocess runs

## app.state additions
- `bundles_ready: asyncio.Event` — set on prewarm success or failure
- `prewarm_task: asyncio.Task | None` — cancellable task reference
- `prewarm_error: str | None` — error message for loading screen

## Testing
- 493 tests passing (9 new covering lifespan, /ready, prewarm failure, PreparedBundle cache)

## Companion PR
Works with https://github.com/microsoft/amplifier-distro/pull/201 (loading screen, overlay registration, live-reload)