### PR TITLE
feat: SSE reliability — logging, keepalive, sequence IDs, error isolation

### DIFF
--- a/src/amplifierd/routes/events.py
+++ b/src/amplifierd/routes/events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncGenerator
 
 from fastapi import APIRouter, Request
@@ -10,13 +11,14 @@ from starlette.responses import StreamingResponse
 
 from amplifierd.state.event_bus import EventBus
 
-events_router = APIRouter(tags=["events"])
+logger = logging.getLogger(__name__)
 
-_KEEPALIVE_INTERVAL: float = 15.0
+events_router = APIRouter(tags=["events"])
 
 
 async def _event_generator(
     event_bus: EventBus,
+    request: Request,
     session_id: str | None = None,
     filter_patterns: list[str] | None = None,
 ) -> AsyncGenerator[str]:
@@ -24,16 +26,36 @@ async def _event_generator(
 
     Each event is serialized via ``event.to_sse_dict()`` with
     ``json.dumps(ensure_ascii=False)``.  A keepalive comment is sent
-    every ``_KEEPALIVE_INTERVAL`` seconds to prevent proxy timeouts.
+    when the EventBus yields a ``None`` sentinel (no events for
+    ``_KEEPALIVE_INTERVAL`` seconds) to prevent proxy timeouts and
+    enable disconnect detection.
     """
     async for event in event_bus.subscribe(
         session_id=session_id,
         filter_patterns=filter_patterns,
     ):
-        sse_dict = event.to_sse_dict()
-        name = sse_dict.get("event", event.event_name)
-        data = json.dumps(sse_dict, ensure_ascii=False)
-        yield f"event: {name}\ndata: {data}\n\n"
+        if await request.is_disconnected():
+            logger.info("SSE client disconnected: session=%s", session_id)
+            break
+
+        # Keepalive sentinel from EventBus.subscribe()
+        if event is None:
+            yield ": keepalive\n\n"
+            continue
+
+        # Per-event error isolation — skip bad events, don't kill stream
+        try:
+            sse_dict = event.to_sse_dict()
+            name = sse_dict.get("event", event.event_name)
+            data = json.dumps(sse_dict, ensure_ascii=False)
+            yield f"id: {event.sequence}\nevent: {name}\ndata: {data}\n\n"
+        except Exception:
+            logger.exception(
+                "SSE serialization error for event=%s session=%s",
+                event.event_name,
+                session_id,
+            )
+            continue
 
 
 @events_router.get("/events")
@@ -53,6 +75,7 @@ async def stream_events(
     return StreamingResponse(
         _event_generator(
             event_bus=event_bus,
+            request=request,
             session_id=session,
             filter_patterns=filter_patterns,
         ),

--- a/src/amplifierd/state/event_bus.py
+++ b/src/amplifierd/state/event_bus.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections import deque
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
 
 from amplifierd.state.transport_event import TransportEvent
+
+logger = logging.getLogger(__name__)
+
+_KEEPALIVE_INTERVAL: float = 15.0
 
 
 class _Subscriber:
@@ -123,6 +128,12 @@ class EventBus:
                     except asyncio.QueueEmpty:
                         pass
                     sub.queue.put_nowait(event)
+                    logger.warning(
+                        "EventBus queue full for subscriber session=%s; "
+                        "dropped oldest event (current_event=%s)",
+                        sub.session_id,
+                        event_name,
+                    )
 
     # ------------------------------------------------------------------
     # Subscribe (async generator)
@@ -132,15 +143,24 @@ class EventBus:
         self,
         session_id: str | None = None,
         filter_patterns: list[str] | None = None,
-    ) -> AsyncIterator[TransportEvent]:
+    ) -> AsyncIterator[TransportEvent | None]:
         """Async generator yielding TransportEvents for this subscriber."""
         queue: asyncio.Queue[TransportEvent] = asyncio.Queue(maxsize=self._MAX_QUEUE_SIZE)
         sub = _Subscriber(session_id=session_id, filter_patterns=filter_patterns, queue=queue)
         self._subscribers.append(sub)
+        logger.info(
+            "SSE subscriber connected: session=%s (total=%d)",
+            session_id,
+            len(self._subscribers),
+        )
         sequence = 0
         try:
             while True:
-                raw = await queue.get()
+                try:
+                    raw = await asyncio.wait_for(queue.get(), timeout=_KEEPALIVE_INTERVAL)
+                except TimeoutError:
+                    yield None  # Keepalive sentinel for SSE generator
+                    continue
                 sequence += 1
                 event = TransportEvent(
                     event_name=raw.event_name,
@@ -153,3 +173,8 @@ class EventBus:
                 yield event
         finally:
             self._subscribers.remove(sub)
+            logger.info(
+                "SSE subscriber disconnected: session=%s (total=%d)",
+                session_id,
+                len(self._subscribers),
+            )

--- a/tests/test_events_route.py
+++ b/tests/test_events_route.py
@@ -7,6 +7,7 @@ import json
 
 import pytest
 from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
 
 from amplifierd.app import create_app
 from amplifierd.routes.events import _event_generator
@@ -30,14 +31,18 @@ class TestEventGenerator:
                 data={"hello": "world"},
             )
 
+        # Mock request with is_disconnected() returning False
+        mock_request = MagicMock()
+        mock_request.is_disconnected = AsyncMock(return_value=False)
+
         task = asyncio.create_task(publish_after_delay())
-        gen = _event_generator(event_bus)
+        gen = _event_generator(event_bus, request=mock_request)
         sse_chunk = await asyncio.wait_for(gen.__anext__(), timeout=2.0)
         await gen.aclose()
         await task
 
-        # Verify SSE format: 'event: {name}\ndata: {json}\n\n'
-        assert sse_chunk.startswith("event: test:event\n")
+        # Verify SSE format: 'id: {id}\nevent: {name}\ndata: {json}\n\n'
+        assert sse_chunk.startswith("id: 1\nevent: test:event\n")
         assert "data: " in sse_chunk
         assert sse_chunk.endswith("\n\n")
 


### PR DESCRIPTION
## Problem

The EventBus and SSE endpoint had zero observability and several reliability gaps:

- **Silent event drops**: Queue overflow (10,000 max) silently discarded oldest events with no logging
- **No keepalive**: `_KEEPALIVE_INTERVAL = 15.0` was declared but never implemented — proxy/browser timeouts would kill idle SSE connections
- **Zombie subscribers**: Disconnected clients were never detected, leaving subscribers with filling queues (memory leak)
- **No SSE `id:` field**: Browser's native `Last-Event-ID` reconnection mechanism was completely non-functional
- **Stream-killing errors**: A single malformed event would crash the entire SSE generator

## Changes

### EventBus (`state/event_bus.py`)
- `logger.warning()` on `QueueFull` — was completely silent
- `logger.info()` on subscriber connect/disconnect with total count
- `asyncio.wait_for(queue.get(), timeout=15.0)` in `subscribe()` — yields `None` sentinel for keepalive
- Return type updated to `AsyncIterator[TransportEvent | None]`

### SSE Endpoint (`routes/events.py`)
- `id: {sequence}` field in SSE frames — enables browser `Last-Event-ID` tracking
- `: keepalive\n\n` comment every 15s — prevents proxy timeouts, enables disconnect detection
- `try/except` per event — serialization failure skips one event instead of killing the stream
- `request.is_disconnected()` check — cleans up zombie subscribers
- Removed dead `_KEEPALIVE_INTERVAL` constant

### Tests
- Updated `test_published_event_received_via_generator` for new `request` parameter and `id:` field

## Testing

All 8 tests pass:
- `test_event_bus.py` (5 tests) — publish, subscribe, session filter, tree propagation, sequence isolation
- `test_events_route.py` (3 tests) — generator, headers, router registration

## Related

This is the daemon-side half of SSE reliability. The companion chat plugin PR (amplifier-chat) will add:
- Unconditional release on `prompt_complete` (fixes stuck-UI bug)
- REST state reconciliation on SSE reconnect