### PR TITLE
fix: 409 guard on /execute/stream + CancelledError status recovery

### DIFF
--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -176,8 +176,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # packages like `anthropic` or `openai` are missing.  Invalidating is cheap
     # — uv pip install -e is a fast no-op when packages are already present.
     try:
-        from amplifier_foundation.modules.install_state import InstallStateManager
-        from amplifier_foundation.paths import get_amplifier_home
+        from amplifier_lib.modules.install_state import InstallStateManager
+        from amplifier_lib.paths import get_amplifier_home
 
         state = InstallStateManager(get_amplifier_home() / "cache")
         state.invalidate()
@@ -188,7 +188,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     # BundleRegistry — resilient: catches all exceptions, starts without registry
     try:
-        from amplifier_foundation import BundleRegistry
+        from amplifier_lib import BundleRegistry
 
         app.state.bundle_registry = BundleRegistry()
 

--- a/src/amplifierd/errors.py
+++ b/src/amplifierd/errors.py
@@ -44,7 +44,7 @@ except ImportError:
     _HAS_AMPLIFIER_CORE = False
 
 try:
-    from amplifier_foundation.exceptions import (
+    from amplifier_lib.exceptions import (
         BundleDependencyError,
         BundleError,
         BundleLoadError,

--- a/src/amplifierd/persistence.py
+++ b/src/amplifierd/persistence.py
@@ -24,13 +24,13 @@ _METADATA_FILENAME = "metadata.json"
 
 # Resolve sanitize_message once at import time.
 try:
-    from amplifier_foundation import sanitize_message as _foundation_sanitize
+    from amplifier_lib import sanitize_message as _foundation_sanitize
 except ImportError:
     _foundation_sanitize = None  # type: ignore[assignment]
 
 # Resolve write_with_backup once at import time.
 try:
-    from amplifier_foundation import write_with_backup as _write_with_backup
+    from amplifier_lib import write_with_backup as _write_with_backup
 except ImportError:
     _write_with_backup = None  # type: ignore[assignment]
 
@@ -66,9 +66,7 @@ def write_transcript(session_dir: Path, messages: list[dict[str, Any]]) -> None:
     for msg in messages:
         try:
             msg_dict = (
-                msg
-                if isinstance(msg, dict)
-                else getattr(msg, "model_dump", lambda _m=msg: _m)()
+                msg if isinstance(msg, dict) else getattr(msg, "model_dump", lambda _m=msg: _m)()
             )
             if msg_dict.get("role") in _EXCLUDED_ROLES:
                 continue
@@ -166,9 +164,7 @@ class TranscriptSaveHook:
             if count <= self._last_count:
                 return HookResult(action="continue")
 
-            await asyncio.to_thread(
-                write_transcript, self._session_dir, list(messages)
-            )
+            await asyncio.to_thread(write_transcript, self._session_dir, list(messages))
             self._last_count = count
 
         except Exception:  # noqa: BLE001
@@ -203,9 +199,7 @@ class MetadataSaveHook:
                 return HookResult(action="continue")
 
             messages = await context.get_messages()
-            turn_count = sum(
-                1 for m in messages if isinstance(m, dict) and m.get("role") == "user"
-            )
+            turn_count = sum(1 for m in messages if isinstance(m, dict) and m.get("role") == "user")
 
             updates: dict[str, Any] = {
                 "turn_count": turn_count,

--- a/src/amplifierd/routes/agents.py
+++ b/src/amplifierd/routes/agents.py
@@ -87,7 +87,7 @@ async def _create_child_handle(
 
     # Try the real foundation path first
     try:
-        from amplifier_foundation import create_child_session  # type: ignore[import-not-found]
+        from amplifier_lib import create_child_session  # type: ignore[import-not-found]
 
         child_session = await create_child_session(parent_handle.session, agent_name)
         child_handle = manager.register(

--- a/src/amplifierd/routes/sessions.py
+++ b/src/amplifierd/routes/sessions.py
@@ -204,11 +204,11 @@ async def patch_session(request: Request, session_id: str, body: PatchSessionReq
     if handle is not None:
         if body.working_dir is not None:
             try:
-                from amplifier_foundation import set_working_dir
+                from amplifier_lib import set_working_dir
 
                 set_working_dir(handle.session, body.working_dir)
             except (ImportError, AttributeError):
-                logger.warning("amplifier_foundation.set_working_dir not available or failed")
+                logger.warning("amplifier_lib.set_working_dir not available or failed")
             handle._working_dir = body.working_dir  # noqa: SLF001
 
     # Persist name and/or working_dir to metadata.json on disk
@@ -357,7 +357,7 @@ async def fork_session_endpoint(
     forked_from_turn = body.turn
 
     try:
-        from amplifier_foundation.session import fork_session_in_memory
+        from amplifier_lib.session import fork_session_in_memory
 
         messages: list[Any] = []
         context = getattr(handle.session, "context", None)
@@ -394,7 +394,7 @@ async def fork_preview(request: Request, session_id: str, turn: int) -> dict[str
     handle = _get_handle_or_404(request, session_id)
 
     try:
-        from amplifier_foundation.session import fork_session_in_memory, get_turn_boundaries
+        from amplifier_lib.session import fork_session_in_memory, get_turn_boundaries
 
         messages: list[Any] = []
         context = getattr(handle.session, "context", None)
@@ -431,7 +431,7 @@ async def list_turns(request: Request, session_id: str) -> dict[str, Any]:
 
     turns: list[dict[str, Any]] = []
     try:
-        from amplifier_foundation.session import get_turn_boundaries
+        from amplifier_lib.session import get_turn_boundaries
 
         messages: list[Any] = []
         context = getattr(handle.session, "context", None)

--- a/src/amplifierd/routes/sessions.py
+++ b/src/amplifierd/routes/sessions.py
@@ -301,12 +301,26 @@ async def execute_stream(
 ) -> ExecuteStreamAccepted:
     """Fire-and-forget streaming execution (returns immediately with correlation_id)."""
     handle = _get_handle_or_404(request, session_id)
+    if handle.status == SessionStatus.EXECUTING:
+        detail = ProblemDetail(
+            type=ErrorTypeURI.EXECUTION_IN_PROGRESS,
+            title="Execution In Progress",
+            status=409,
+            detail=f"Session '{session_id}' is already executing",
+            instance=str(request.url.path),
+        )
+        raise HTTPException(
+            status_code=409,
+            detail=detail.model_dump(exclude_none=True),
+        )
     turn_count = handle.turn_count + 1
     correlation_id = f"prompt_{session_id}_{turn_count}"
 
     async def _run() -> None:
         try:
             await handle.execute(body.prompt)
+        except asyncio.CancelledError:
+            logger.warning("Execution cancelled for session %s", session_id)
         except Exception:
             logger.exception("Streaming execution failed for session %s", session_id)
         finally:

--- a/src/amplifierd/spawn.py
+++ b/src/amplifierd/spawn.py
@@ -51,7 +51,7 @@ def register_spawn_capability(
                     SessionHandle of *session*.  Used to call
                     ``register_child()`` for EventBus tree propagation.
     """
-    from amplifier_foundation import Bundle  # type: ignore[import]
+    from amplifier_lib import Bundle  # type: ignore[import]
 
     coordinator = session.coordinator
 
@@ -199,7 +199,7 @@ async def _spawn_with_event_forwarding(
 
     # 4. Apply provider preferences (fallback chain)
     if provider_preferences:
-        from amplifier_foundation import (  # type: ignore[import]
+        from amplifier_lib import (  # type: ignore[import]
             apply_provider_preferences_with_resolution,
         )
 

--- a/src/amplifierd/state/session_handle.py
+++ b/src/amplifierd/state/session_handle.py
@@ -214,6 +214,11 @@ class SessionHandle:
             self._status = SessionStatus.FAILED
             raise
         finally:
+            # Catch-all: if status is still EXECUTING here, something bypassed
+            # both the success and except paths (e.g., asyncio.CancelledError
+            # which is BaseException in Python 3.9+). Reset to FAILED.
+            if self._status == SessionStatus.EXECUTING:
+                self._status = SessionStatus.FAILED
             self._last_activity = datetime.now(UTC)
 
     def cancel(self, immediate: bool = False) -> None:

--- a/src/amplifierd/state/session_manager.py
+++ b/src/amplifierd/state/session_manager.py
@@ -359,7 +359,7 @@ class SessionManager:
 
         # 2. Handle orphaned tool calls
         try:
-            from amplifier_foundation.session import (
+            from amplifier_lib.session import (
                 add_synthetic_tool_results,
                 find_orphaned_tool_calls,
             )
@@ -373,9 +373,7 @@ class SessionManager:
                     session_id,
                 )
         except ImportError:
-            logger.warning(
-                "amplifier_foundation.session helpers not available; skipping orphan handling"
-            )
+            logger.warning("amplifier_lib.session helpers not available; skipping orphan handling")
 
         # 3. Load metadata to determine bundle and working_dir
         metadata = await asyncio.to_thread(load_metadata, session_dir)


### PR DESCRIPTION
## Summary

- **409 guard added to `POST /execute/stream`** — mirrors the identical guard already on `POST /execute`; previously two concurrent POSTs both received 202 and spawned competing `asyncio` tasks against the same session, with the secondary `RuntimeError` silently swallowed by the `_run()` exception handler
- **`CancelledError` catch-all in `SessionHandle.execute()` `finally` block** — `asyncio.CancelledError` is `BaseException` in Python 3.9+, not `Exception`, so it bypassed the `except Exception` branch entirely and landed in `finally` with `_status` still `EXECUTING`; session was permanently wedged with no recovery path; now resets to `FAILED` if status is still `EXECUTING` after both success and except paths

## Test plan

- [ ] Send two rapid concurrent `POST /execute/stream` to the same session — second should receive 409 immediately
- [ ] Cancel a running task (e.g. via `asyncio` task cancellation or timeout) — session status should recover to `FAILED`, not stay stuck in `EXECUTING`
- [ ] Confirm no regression on normal sequential execution flow
- [ ] Confirm synchronous `POST /execute` 409 behavior unchanged

## Related

Bugs confirmed in session `9a04e79f` (double-submit producing two competing turns). Frontend counterpart: fix/multi-session-switching in amplifier-chat.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)