### PR TITLE
fix: replace amplifier_lib imports with amplifier_foundation

### DIFF
--- a/src/amplifierd/app.py
+++ b/src/amplifierd/app.py
@@ -176,8 +176,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # packages like `anthropic` or `openai` are missing.  Invalidating is cheap
     # — uv pip install -e is a fast no-op when packages are already present.
     try:
-        from amplifier_lib.modules.install_state import InstallStateManager
-        from amplifier_lib.paths import get_amplifier_home
+        from amplifier_foundation.modules.install_state import InstallStateManager
+        from amplifier_foundation.paths import get_amplifier_home
 
         state = InstallStateManager(get_amplifier_home() / "cache")
         state.invalidate()
@@ -188,7 +188,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     # BundleRegistry — resilient: catches all exceptions, starts without registry
     try:
-        from amplifier_lib import BundleRegistry
+        from amplifier_foundation import BundleRegistry
 
         app.state.bundle_registry = BundleRegistry()
 

--- a/src/amplifierd/errors.py
+++ b/src/amplifierd/errors.py
@@ -45,7 +45,7 @@ except ImportError:
     _HAS_AMPLIFIER_CORE = False
 
 try:
-    from amplifier_lib.exceptions import (
+    from amplifier_foundation.exceptions import (
         BundleDependencyError,
         BundleError,
         BundleLoadError,

--- a/src/amplifierd/persistence.py
+++ b/src/amplifierd/persistence.py
@@ -24,13 +24,13 @@ _METADATA_FILENAME = "metadata.json"
 
 # Resolve sanitize_message once at import time.
 try:
-    from amplifier_lib import sanitize_message as _foundation_sanitize
+    from amplifier_foundation import sanitize_message as _foundation_sanitize
 except ImportError:
     _foundation_sanitize = None  # type: ignore[assignment]
 
 # Resolve write_with_backup once at import time.
 try:
-    from amplifier_lib import write_with_backup as _write_with_backup
+    from amplifier_foundation import write_with_backup as _write_with_backup
 except ImportError:
     _write_with_backup = None  # type: ignore[assignment]
 

--- a/src/amplifierd/routes/agents.py
+++ b/src/amplifierd/routes/agents.py
@@ -87,7 +87,7 @@ async def _create_child_handle(
 
     # Try the real foundation path first
     try:
-        from amplifier_lib import create_child_session  # type: ignore[import-not-found]
+        from amplifier_foundation import create_child_session  # type: ignore[import-not-found]
 
         child_session = await create_child_session(parent_handle.session, agent_name)
         child_handle = manager.register(

--- a/src/amplifierd/routes/sessions.py
+++ b/src/amplifierd/routes/sessions.py
@@ -204,11 +204,11 @@ async def patch_session(request: Request, session_id: str, body: PatchSessionReq
     if handle is not None:
         if body.working_dir is not None:
             try:
-                from amplifier_lib import set_working_dir
+                from amplifier_foundation import set_working_dir
 
                 set_working_dir(handle.session, body.working_dir)
             except (ImportError, AttributeError):
-                logger.warning("amplifier_lib.set_working_dir not available or failed")
+                logger.warning("amplifier_foundation.set_working_dir not available or failed")
             handle._working_dir = body.working_dir  # noqa: SLF001
 
     # Persist name and/or working_dir to metadata.json on disk
@@ -357,7 +357,7 @@ async def fork_session_endpoint(
     forked_from_turn = body.turn
 
     try:
-        from amplifier_lib.session import fork_session_in_memory
+        from amplifier_foundation.session import fork_session_in_memory
 
         messages: list[Any] = []
         context = getattr(handle.session, "context", None)
@@ -394,7 +394,7 @@ async def fork_preview(request: Request, session_id: str, turn: int) -> dict[str
     handle = _get_handle_or_404(request, session_id)
 
     try:
-        from amplifier_lib.session import fork_session_in_memory, get_turn_boundaries
+        from amplifier_foundation.session import fork_session_in_memory, get_turn_boundaries
 
         messages: list[Any] = []
         context = getattr(handle.session, "context", None)
@@ -431,7 +431,7 @@ async def list_turns(request: Request, session_id: str) -> dict[str, Any]:
 
     turns: list[dict[str, Any]] = []
     try:
-        from amplifier_lib.session import get_turn_boundaries
+        from amplifier_foundation.session import get_turn_boundaries
 
         messages: list[Any] = []
         context = getattr(handle.session, "context", None)

--- a/src/amplifierd/spawn.py
+++ b/src/amplifierd/spawn.py
@@ -51,7 +51,7 @@ def register_spawn_capability(
                     SessionHandle of *session*.  Used to call
                     ``register_child()`` for EventBus tree propagation.
     """
-    from amplifier_lib import Bundle  # type: ignore[import]
+    from amplifier_foundation import Bundle  # type: ignore[import]
 
     coordinator = session.coordinator
 
@@ -199,7 +199,7 @@ async def _spawn_with_event_forwarding(
 
     # 4. Apply provider preferences (fallback chain)
     if provider_preferences:
-        from amplifier_lib import (  # type: ignore[import]
+        from amplifier_foundation import (  # type: ignore[import]
             apply_provider_preferences_with_resolution,
         )
 

--- a/src/amplifierd/state/session_manager.py
+++ b/src/amplifierd/state/session_manager.py
@@ -359,7 +359,7 @@ class SessionManager:
 
         # 2. Handle orphaned tool calls
         try:
-            from amplifier_lib.session import (
+            from amplifier_foundation.session import (
                 add_synthetic_tool_results,
                 find_orphaned_tool_calls,
             )
@@ -373,7 +373,9 @@ class SessionManager:
                     session_id,
                 )
         except ImportError:
-            logger.warning("amplifier_lib.session helpers not available; skipping orphan handling")
+            logger.warning(
+                "amplifier_foundation.session helpers not available; skipping orphan handling"
+            )
 
         # 3. Load metadata to determine bundle and working_dir
         metadata = await asyncio.to_thread(load_metadata, session_dir)


### PR DESCRIPTION
PR #23 (7bbabb2) re-introduced `amplifier_lib` import references, undoing the fix at 1bd9b24. This causes `ModuleNotFoundError: No module named 'amplifier_lib'` at runtime since no package provides that module.

Replaces all `amplifier_lib` → `amplifier_foundation` across 7 files.