### PR TITLE
fix: use parent_session instead of undefined session in spawn

### DIFF
--- a/src/amplifierd/spawn.py
+++ b/src/amplifierd/spawn.py
@@ -340,7 +340,7 @@ async def _spawn_with_event_forwarding(
     parent_handle.register_child(child_session.session_id, agent_name)
 
     # 13b. Link cancellation tokens so cancelling the parent propagates to the child.
-    parent_cancel = getattr(session.coordinator, "cancellation", None)
+    parent_cancel = getattr(parent_session.coordinator, "cancellation", None)
     child_cancel = getattr(child_session.coordinator, "cancellation", None)
     if parent_cancel and child_cancel:
         parent_cancel.register_child(child_cancel)


### PR DESCRIPTION
## Problem

`_spawn_with_event_forwarding()` in `spawn.py` references a bare `session` variable at line 343 when linking cancellation tokens, but the function's parameter is `parent_session`. This causes a **`NameError: name 'session' is not defined`** that breaks **ALL agent delegation** in amplifierd sessions.

## Root Cause

Introduced in 2c7ce15 (#25) which added cancellation propagation to child sessions. The outer `register_spawn_capability()` function has a `session` parameter, but `_spawn_with_event_forwarding()` is a **standalone function, not a closure**, so it cannot see that variable.

```python
# BUG (line 343):
parent_cancel = getattr(session.coordinator, "cancellation", None)

# FIX:
parent_cancel = getattr(parent_session.coordinator, "cancellation", None)
```

## Impact

Every call to the `delegate` tool fails immediately, making agent delegation completely non-functional. This affects all amplifierd sessions.

## Fix

One-line change: `session` → `parent_session` on line 343, consistent with every other reference to the parent in that function.