### PR TITLE
fix: eliminate race conditions in SessionIndex.save()

### DIFF
--- a/src/amplifierd/state/session_index.py
+++ b/src/amplifierd/state/session_index.py
@@ -70,6 +70,10 @@ class SessionIndex:
                 os.replace(tmp_name, str(self._path))
             except BaseException:
                 try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                try:
                     os.unlink(tmp_name)
                 except OSError:
                     pass

--- a/src/amplifierd/state/session_index.py
+++ b/src/amplifierd/state/session_index.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
+import threading
 from dataclasses import asdict, dataclass
 from dataclasses import fields as dc_fields
 from pathlib import Path
@@ -28,6 +30,7 @@ class SessionIndex:
     def __init__(self, path: Path) -> None:
         self._path = path
         self._entries: dict[str, SessionIndexEntry] = {}
+        self._save_lock = threading.Lock()
 
     def add(self, entry: SessionIndexEntry) -> None:
         self._entries[entry.session_id] = entry
@@ -52,11 +55,25 @@ class SessionIndex:
         return list(self._entries.values())
 
     def save(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix(".json.tmp")
-        data = [asdict(e) for e in self._entries.values()]
-        tmp.write_text(json.dumps(data, indent=2))
-        os.rename(tmp, self._path)
+        with self._save_lock:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            # Snapshot entries to avoid "dictionary changed size during iteration"
+            # when add() is called concurrently from the event loop.
+            entries_snapshot = list(self._entries.values())
+            data = [asdict(e) for e in entries_snapshot]
+            # Use a unique temp file to prevent races between concurrent save() callers
+            # (the lock serializes within one process, but unique names are safer).
+            fd, tmp_name = tempfile.mkstemp(dir=self._path.parent, suffix=".tmp", prefix=".index-")
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(data, f, indent=2)
+                os.replace(tmp_name, str(self._path))
+            except BaseException:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+                raise
 
     @classmethod
     def load(cls, path: Path) -> SessionIndex:
@@ -100,9 +117,7 @@ class SessionIndex:
                             status=meta.get("status", "completed"),
                             bundle=meta.get("bundle", "unknown"),
                             created_at=meta.get("created_at", ""),
-                            last_activity=meta.get(
-                                "last_activity", meta.get("created_at", "")
-                            ),
+                            last_activity=meta.get("last_activity", meta.get("created_at", "")),
                             parent_session_id=meta.get("parent_session_id"),
                             project_id=project_dir.name,
                         )

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -34,7 +34,7 @@ def test_atomic_write(tmp_path):
         )
     )
     index.save()
-    assert not (tmp_path / "index.json.tmp").exists()
+    assert list(tmp_path.glob(".index-*.tmp")) == []
     assert (tmp_path / "index.json").exists()
 
 


### PR DESCRIPTION
## Summary

- **Race 1 — `FileNotFoundError`:** All concurrent `save()` callers shared the same fixed temp filename (`index.json.tmp`). The first caller's `os.rename()` consumed the file; every subsequent caller raised `FileNotFoundError`.
- **Race 2 — `RuntimeError: dictionary changed size during iteration`:** `save()` iterated `self._entries.values()` in a thread-pool worker while `add()` mutated the dict from the asyncio event loop concurrently.
- Both races were introduced in **9239f09** (2026-03-06) when `save()` was wrapped in `asyncio.to_thread()` and have been latent since, surfacing as **11 confirmed `FileNotFoundError`s + 1 `RuntimeError`** in a single distro session triggered by 2-3 parallel agent delegations.

## Root cause

When parallel agent delegations fire 2-3 concurrent `register()` calls, each wraps `save()` in `asyncio.to_thread()`. Prior to this fix all callers raced on the same `.tmp` path and iterated a live dict being mutated by the event loop.

## Fix (3 parts)

1. **Dict snapshot** — `list(self._entries.values())` before iterating prevents `RuntimeError: dictionary changed size during iteration`
2. **Unique temp files** — `tempfile.mkstemp()` gives each `save()` call its own temp file, eliminating the shared `index.json.tmp` collision
3. **threading.Lock + os.replace() + cleanup guard** — serializes concurrent callers within a process, ensures atomic rename, unlinks orphaned temp files on failure

## Impact

Affects **amplifier-distro**, **amplifierd**, and **amplifier-chat** — all depend on the same `SessionIndex`.

## Test plan

- [ ] `uv run pytest tests/test_session_index.py`
- [ ] Trigger parallel agent delegation (2-3 concurrent `register()` calls) and confirm no `FileNotFoundError` or `RuntimeError` in logs
- [ ] Confirm `index.json` is written atomically with no leftover `.tmp` files after concurrent saves

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)