### PR TITLE
Bridge llm:stream_block_* token-delta events to SSE

### DIFF
--- a/src/amplifierd/state/session_handle.py
+++ b/src/amplifierd/state/session_handle.py
@@ -140,7 +140,14 @@ class SessionHandle:
             "delegate:agent_completed",
             "delegate:error",
         ]
-        all_events = list(ALL_EVENTS) + _delegate_events
+        # Provider token-delta streaming events — bridged to SSE so HTTP/WS
+        # clients (e.g. the Kepler desktop app) can render streaming replies.
+        _streaming_events = [
+            "llm:stream_block_start",
+            "llm:stream_block_delta",
+            "llm:stream_block_end",
+        ]
+        all_events = list(ALL_EVENTS) + _delegate_events + _streaming_events
 
         registered = 0
         for event_name in all_events:


### PR DESCRIPTION
## What

Adds the three provider token-delta streaming events to the per-session bridged-event list in `session_handle.py`:

- `llm:stream_block_start`
- `llm:stream_block_delta`
- `llm:stream_block_end`

## Why

HTTP/WS clients consuming amplifierd's SSE stream currently only receive non-streaming completion events — provider token deltas are emitted on the session event bus but are not in the bridged set, so streaming replies never reach SSE consumers. The Kepler desktop app (which talks to amplifierd over HTTP/SSE) needs these to render streaming LLM output token-by-token.

This is purely additive — three event names appended to the bridged list; no behavior change for existing consumers.

## Test

Verified end-to-end in the Kepler app: with these events bridged, a WS `/chat` turn streams token deltas; without them, only the final completion arrives.